### PR TITLE
Audit 2026-09-01: stop the system asserting policy it does not have

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,10 @@ access` while `psql -l` on the same database works fine.
 `DATABASE_URL` in `.env` is the hosted Postgres the pilot runs on. Any script
 run without an explicit override writes to real data. `npm test` is safe by
 construction (its setup refuses a database whose name lacks `test`), but the
-`policies:*` and `prisma` commands are not: they take whatever `.env` gives
-them. Re-indexing against production with an unmigrated schema is what once
+`policies:*` and `prisma` commands are not, and neither are
+`scripts/test-phase3.ts` and `scripts/test-rag.ts`, which create and delete
+`User`, `Incident`, `Conversation` and `Policy` rows despite the `test-`
+prefix. They take whatever `.env` gives them. Re-indexing against production with an unmigrated schema is what once
 left every policy with zero chunks and retrieval silently returning nothing.
 Prefer `npm run policies:reindex` with no flag — it is a dry run — and read what
 it says it would do before passing `--apply`.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,25 @@ docker run -p 8000:8000 chromadb/chroma
 | `npm run policies:coverage` | What the library can and cannot answer |
 
 `scripts/test-*.ts` are **manual demo scripts, not automated tests** — they
-print a transcript and assert nothing. They need a running server and read
-`APP_BASE_URL` (default `http://localhost:3000`).
+print a transcript and assert nothing. They fall into three groups, and the
+difference matters:
+
+- `test-chat-behavior.ts`, `test-complete-rag.ts`, `test-lawyer-persona.ts`
+  need a running server and read `APP_BASE_URL` (default
+  `http://localhost:3000`). They POST to `/api/chat`, which requires a
+  session, so they return 401 unless `APP_SESSION_COOKIE` is set.
+- `test-phase3.ts` and `test-rag.ts` use **no server**. They connect with
+  Prisma and **create and delete `User`, `Incident`, `Conversation` and
+  `Policy` rows in whatever `DATABASE_URL` points at**, with best-effort
+  cleanup that a mid-run failure will skip. `.env` points at production, so
+  always override it:
+
+  ```bash
+  DATABASE_URL="postgresql://$USER@localhost:5432/generalschat_test?schema=public" \
+  npx tsx scripts/test-rag.ts
+  ```
+
+- `test-claude.ts` makes a **billed** Anthropic call.
 
 ## How policies are modelled
 
@@ -196,7 +213,7 @@ The end-to-end suite covers the journeys and access control:
 
 ```bash
 createdb generalschat_test
-DATABASE_URL="postgresql://localhost:5432/generalschat_test?schema=public" \
+DATABASE_URL="postgresql://$USER@localhost:5432/generalschat_test?schema=public" \
 AUTH_SECRET="$(openssl rand -base64 32)" \
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -285,12 +285,24 @@ environment; `docker-compose.yml` will refuse to start without `AUTH_SECRET`.
 
 ## Security status
 
-An audit on 2026-08-31 found 153 issues. The blocking ones are fixed:
-authentication and authorization, arbitrary file write on both upload paths,
-SSRF in the policy URL fetch, attachments served from `public/` with no access
-check, missing upload size and type limits, unvalidated write bodies and
-pagination, a production container running the dev server, and a page that
-fabricated compliance determinations with `Math.random()`.
+An audit on 2026-08-31 found 153 issues; a second on 2026-09-01 found 142
+more. The 2026-08-31 blockers are all fixed: authentication and authorization,
+arbitrary file write on both upload paths, SSRF in the policy URL fetch,
+attachments served from `public/` with no access check, missing upload size and
+type limits, unvalidated write bodies and pagination, a production container
+running the dev server, and a page that fabricated compliance determinations
+with `Math.random()`.
+
+The 2026-09-01 audit found six blockers. Five are fixed — see
+[`docs/audit/2026-09-01-work-completed.md`](docs/audit/2026-09-01-work-completed.md).
+
+**The sixth is open and you should know it before trusting any deadline this
+tool shows you.** Obligation deadlines are produced by a classification call
+that is never given the retrieved policy, so they are the model's recall of
+New Hampshire law rather than something a policy states, and
+`ComplianceAction` carries no `policyId` to check them against. The fix needs
+a product decision (OQ-5 in the findings). Until it lands, confirm every
+deadline against the cited policy.
 
 Still open, and worth knowing before you deploy:
 

--- a/docs/audit/2026-09-01-findings.md
+++ b/docs/audit/2026-09-01-findings.md
@@ -1,0 +1,582 @@
+# Audit findings — 2026-09-01
+
+Branch `audit/2026-09-01`, cut from `dev` at `d62eb61`.
+
+**Reading note.** This is the findings record. What was actually done about it
+is in [`2026-09-01-work-completed.md`](./2026-09-01-work-completed.md). The
+previous audit is [`2026-08-31-findings.md`](./2026-08-31-findings.md).
+
+## Method
+
+Six parallel read-only passes — spec conformance, security, test quality,
+dead/duplicated code, repo organisation and docs accuracy, and an end-to-end
+trace of the five primary user journeys. Sources of truth, in precedence order:
+`CLAUDE.md` (invariants, design rules, test contracts), `docs/roadmap.md`,
+the 2026-08-31 audit pair, then `README.md` / `POLICY_MAPPING.md` /
+`QUICK_START_POLICY_UPLOAD.md`. `docs/history/` was treated as a record, not a
+spec — `CLAUDE.md` demotes it explicitly.
+
+There is no PRD and no "gap docs" in this repo; the task template's
+placeholders were resolved against what the repo actually contains. The four
+gate commands were taken from `CLAUDE.md` and verified against
+`.github/workflows/ci.yml` — they match: `npm run typecheck`, `npm run lint`,
+`npm run build`, `npm test`.
+
+**Baseline at cut:** all four gates green — 0 type errors, 0 lint errors
+(3 pre-existing warnings), build succeeds, 97 unit + 52 e2e passing.
+
+IDs continue from the 2026-08-31 audit rather than restarting, so a reference
+to `SEC-7` means the same thing in both documents.
+
+## Counts
+
+| | blocker | major | minor | total |
+|---|---|---|---|---|
+| Spec conformance | 1 | 6 | 8 | 15 |
+| Security | 0 | 6 | 5 | 11 |
+| User journeys | 5 | 7 | 9 | 21 |
+| Test quality | 8 | 10 | 7 | 25 |
+| Dead / duplicated | 0 | 9 | 35 | 44 |
+| Docs / repo | 1 | 7 | 18 | 26 |
+| **total (before dedup)** | **15** | **45** | **82** | **142** |
+
+Several findings are one defect seen from different angles. After merging,
+**there are 6 distinct blockers.** The merges are recorded inline.
+
+---
+
+# Blockers
+
+## B1 — Obligation deadlines are invented by the model, which is never shown a policy
+**FLOW-30.** `src/app/api/chat/route.ts:124-130`, `src/lib/ai/classifier.ts:5-15`,
+`:29`, `src/lib/ai/claude-service.ts:354-357`, `:367`
+
+`classifyIncident(message, { incidentId, reporterId })` is called with two
+arguments. The third parameter, `policyContext`, is therefore `undefined`, and
+`claude-service.ts:367` interpolates nothing — **the classification prompt that
+produces every `dueInHours` contains no policy text at all.** The prompt instead
+instructs the model to "use the shortest legally required window … e.g. a
+mandatory DCYF or police report is typically 24 hours", so the deadline is the
+model's recall of New Hampshire law. `classifier.ts:29` converts it directly:
+`dueDate: new Date(Date.now() + action.dueInHours * 3600_000)`.
+`ComplianceAction` has no `policyId` and no `citation` column
+(`prisma/schema.prisma:117-137`), so nothing can be reconciled afterwards.
+
+**Violates** `CLAUDE.md` data model: *"`ComplianceAction` rows are the
+obligations, created at classification **with the deadline the policy sets**."*
+And the header: *"a confidently wrong statutory deadline is worse than no
+answer."*
+
+Three surfaces assert the opposite to the user: `src/app/page.tsx:134`
+("with the deadline the policy sets"), `src/app/policies/page.tsx:104`
+("Deadlines are still correct"), and `ObligationRow.tsx:71-78`, which renders an
+`AuthorityChip` only when a citation exists — it never does.
+
+**Scenario.** *"A 4th grader told the counselor this morning that her stepfather
+hits her."* Classification returns `other` with `{description: "File a report
+with DCYF", dueInHours: 24}`. The home queue shows **"File a report with DCYF —
+in 23h 41m"**. No retrieved policy was consulted, and per the roadmap no
+`mandatory_reporting` policy is loaded at all. RSA 169-C:29 requires a report
+*immediately*; a 24-hour countdown is affirmatively misleading on the most
+time-critical obligation in the product.
+
+**Fix.** Two-phase: after retrieval (`route.ts:174-182`), re-derive obligations
+with a second `classifyIncident` call that receives `policyContext`, and drop
+any action whose deadline cannot be attributed to a supplied excerpt. This is a
+product decision about behaviour under a thin library — **logged as OQ-5, not
+fixed unattended.** The honest interim, which *is* in scope: stop the three UI
+strings claiming provenance the data does not have.
+
+## B2 — A policy row with zero chunks silences the coverage gap it should raise
+**SPEC-36 = FLOW-31 = TEST-29** (found independently by three passes).
+`src/lib/ai/rag.ts:494-498`
+
+```ts
+const policies = await prisma.policy.findMany({
+  where: { isActive: true, category: { in: categories } },   // no chunk predicate
+```
+
+`src/lib/policy-coverage.ts:71-78` states the opposite rule for itself: *"A
+policy only counts as covering something if it is active AND has chunks. A
+policy row with no chunks is invisible to retrieval, so counting it would report
+coverage the system cannot actually deliver."* The offline CLI report obeys
+this; the live path that decides what the administrator is told does not.
+
+**Violates** `CLAUDE.md`: *"A missing local policy is information. Coverage gaps
+are reported, not hidden."*
+
+Consequence: `categoriesWithoutLocalPolicy` drops the category, so the
+`POLICY COVERAGE GAP` prompt block is suppressed, `CoverageGapCard` returns
+`null`, and `LibraryScopeNote` does not render. Not hypothetical — `CLAUDE.md:41`
+records production reaching exactly this state ("left every policy with zero
+chunks and retrieval silently returning nothing"), and B5 reaches it in one
+click.
+
+**Fix.** `where: { isActive: true, category: { in: categories }, chunks: { some: {} } }`.
+
+## B3 — `other` and unclassified incidents retrieve no mandatory-reporting policy, and every gap warning is suppressed
+**SPEC-39 = FLOW-32 = TEST-25** (three passes). `src/types/index.ts:196`,
+`:213-217`; `src/lib/ai/rag.ts:320-326`, `:355-359`, `:490-492`;
+`src/app/chat/page.tsx:43-47`
+
+`categoriesForIncidentType` returns `[]` for `other` and for `null`, so the
+`ALWAYS_RETRIEVED_CATEGORY` append at `:219` is never reached. Three safeguards
+fail together:
+
+1. `ensureCategoryRepresentation` short-circuits (`rag.ts:359`) — the mechanism
+   that guarantees mandatory-reporting text is present never runs.
+2. Search runs with no category filter, so a keyword hit from any unrelated
+   category is handed to the model as authority.
+3. `assessCoverage([])` returns no gaps, so no prompt block, no card, no note.
+
+**Violates** `CLAUDE.md` data model: *"`mandatory_reporting` is **always**
+included because 'must I report this' is the question the tool exists to
+answer."* `README.md` and `src/types/index.ts:205` both repeat "always".
+
+This is also the classifier's **failure** default (`classifier.ts:100`), and
+`route.ts:123` only classifies when `!incident.incidentType` — so an incident
+whose classification call failed is stamped `other` permanently, with no path in
+the product to correct it.
+
+**Scenario.** Same input as B1. `categories = []`; today's library is
+bullying-only, so keywords like `told`, `counselor`, `stepfather` match JICK
+chunks; `policyContext` is non-empty so the strict no-retrieval guard does *not*
+fire; no gap is reported. The UI renders **"This rests on → District: Policy
+JICK: Bullying Prevention"** beneath guidance about reporting suspected child
+abuse. That is `CLAUDE.md`'s *"passing a statute off as district procedure"*,
+one step worse — passing a bullying policy off as reporting authority.
+
+**Fix.** Keep `categoriesForIncidentType` returning `[]` as the *search filter*,
+but pass `[...categories, ALWAYS_RETRIEVED_CATEGORY]` to
+`ensureCategoryRepresentation` and `assessCoverage`. The comment at `:211-213`
+justifies the empty filter only; it does not justify disabling representation
+and coverage.
+
+## B4 — The summary prompt orders the model to cite policy codes with no retrieval guard, and the result is filed to the incident record
+**SPEC-37 = FLOW-33** (two passes). `src/lib/ai/claude-service.ts:461-530`,
+esp. `:475`, `:493`, `:507`, `:517-519`; `src/lib/ai/incident-summary.ts:57`, `:66`
+
+`generateComplianceResponse` implements the guard (`hasPolicyContext` at `:279`,
+the `NO POLICY RETRIEVED` block at `:305-317`). `generateChatSummary` is a
+separate hardcoded prompt with no such branch, and it still contains the exact
+exemplars the prior audit removed from the chat path:
+
+- `:475` — *"List each policy referenced … with specific codes (e.g., "JICK", "ACAC", "JLF")"*
+- `:493` — *"Include specific deadlines (e.g., "DCYF report due within 24 hours")"*
+- `:507` — *"as it may become part of the incident file. Be specific, cite policies by code"*
+- `:517-519` — `policyContext` interpolated with no empty branch
+
+`policyContext` is `''` whenever retrieval returns nothing (`rag.ts:406`).
+
+**Violates** `CLAUDE.md`: *"Never assert policy the system did not retrieve … the
+prompt gets an explicit instruction not to cite policy codes or state district
+deadlines. Don't remove that guard."* The prior audit fixed this in the chat path
+(FLOW-3/SPEC-3) and its comment at `:270-278` records that the in-prompt
+examples were exactly what the model latched onto. The identical list is still
+standing here.
+
+Aggravating: the summary is **persisted** (`incident-summary.ts:68-81`) and
+rendered in the incident timeline. It is the artefact most likely to be printed
+and filed, and it is the least guarded call in the system.
+
+**Fix.** Branch on `policyContext.trim().length > 0` exactly as `:294-317` does;
+drop the literal code exemplars; extract the no-policy block to a module
+constant used by both.
+
+## B5 — Every upload failure mode reports success, and jurisdiction/category are never validated
+**SEC-26 = SPEC-40 = FLOW-39** (three passes).
+`src/app/api/admin/policies/upload/route.ts:34-35`, `:75-82`, `:106-122`, `:142-156`;
+`src/app/api/policies/route.ts:64-65`; `src/app/api/admin/policies/route.ts:60-61`;
+`src/app/api/admin/policies/[id]/route.ts:57`
+
+No write path validates `jurisdiction` or `category`; all default silently
+(`|| 'district'`, `|| 'other'`). `POLICY_CATEGORIES`/`POLICY_JURISDICTIONS` are
+imported and applied in the **GET** on `api/policies/route.ts:31-36` but not in
+its POST. The four zod schemas written for these handlers
+(`validation.ts:61-104`) are imported nowhere.
+
+A PDF that extracts to `''` is not detected — `countWords` exists precisely to
+make that visible (`documentProcessor.ts:116-122`) and is not consulted — and
+the row is created `isActive: true` regardless. `chunksCreated` is computed and
+returned, then discarded: `admin/policies/page.tsx:96,122,148` all
+`alert('Policy uploaded successfully')` on `response.ok`.
+
+**Violates** `docs/roadmap.md` §3: *"retrieval matches on category, so anything
+loaded as `other` will never be found."* And `CLAUDE.md`'s coverage invariant,
+by way of B2.
+
+**Scenario.** Admin uploads `Mandatory Reporting Procedure.pdf` (a scan). Alert
+says success. `/policies` counts it active. Via **B2**, the next incident's
+mandatory-reporting gap *disappears*, the model answers from memory, and no
+warning appears anywhere. One upload silently deletes a safety warning.
+
+A bad *jurisdiction* is worse than a bad category: `buildJurisdictionContext`
+(`rag.ts:411-441`) groups only over `POLICY_JURISDICTIONS`, and the ungrouped
+branch at `:434` catches only chunks with no `policy` — so the text is dropped
+from the model's context **while `buildCitations` still lists it as a source.**
+
+**Fix.** Parse both through the existing enums and 400 on a miss; reject or
+deactivate when `countWords(content) === 0`; surface `chunksCreated` in the
+admin confirmation.
+
+## B6 — README describes two production-writing scripts as harmless server-only demos
+**DOC-1.** `README.md:93-95`; `scripts/test-phase3.ts:6,44,117,149,231-239`;
+`scripts/test-rag.ts:4,41,110,185-191`
+
+README says all six `scripts/test-*.ts` *"need a running server and read
+`APP_BASE_URL`"*. Only three do. `test-phase3.ts` and `test-rag.ts` import
+`prisma` directly and **create and delete `User`, `Incident`, `Conversation` and
+`Policy` rows**, with best-effort non-transactional cleanup.
+
+`CLAUDE.md:36-42` records that **`.env` points at production** and names only
+`policies:*` and `prisma` as unsafe. A reader following the README runs
+`npx tsx scripts/test-phase3.ts` and writes into the pilot's live student-record
+database.
+
+**Fix.** Correct README:93-95 to describe the three groups separately and state
+the `DATABASE_URL` override; add both scripts to the unsafe list in
+`CLAUDE.md:40`.
+
+---
+
+# Test-quality blockers
+
+These are passing tests that give false assurance. Each is proved by naming a
+real defect that would not fail the suite.
+
+- **TEST-24 — no test asserts a computed deadline.** `classifier.ts:29`.
+  Change `* 60 * 60 * 1000` to `* 60 * 1000` — every 24-hour statutory clock
+  becomes 24 minutes — and all 149 tests still pass. `deadline.test.ts` tests
+  *formatting* of a due date handed to it, never its derivation. **Fix:** unit-test
+  `dueInHours → dueDate` with a fixed clock, plus an e2e assertion on the
+  persisted row.
+- **TEST-25 — classification failure is untested and silent.** See B3.
+- **TEST-26 — the no-retrieval guard is structurally unreachable in the fixture.**
+  `claude-service.ts:294-317`. `mandatory_reporting` is seeded, so `policyContext`
+  is non-empty on every e2e turn. Delete `:305-317` and the suite stays green.
+  **Fix:** unit-test the captured `system` string in both branches; add a stub
+  sentinel so e2e can observe it.
+- **TEST-27 — the cross-user obligation test PATCHes an id that does not exist.**
+  `e2e/incident-management.spec.ts:155-165`. Delete `incident: incidentScope(...)`
+  from `obligations/[id]/route.ts:38` — any user can discharge any obligation —
+  and `does-not-exist-id` still 404s. Test passes. The fixture seeds no foreign
+  obligation, so the real test is impossible to write today.
+- **TEST-28 — "does not expose another user's incident by id" never fetches by id.**
+  `e2e/incident-management.spec.ts:109-113`, `:260-263`. Delete
+  `incidentScope` from `incidents/[id]/route.ts:32` and `:110` — every reporter
+  can read and rewrite every incident in the district — and both tests pass.
+  This is SEC-7 reintroduced with a green suite.
+- **TEST-29 — the tested coverage function is not the one the chat path uses.** See B2.
+- **TEST-30 — attachments have zero coverage of any kind.** No `Attachment` row is
+  ever created in any test. Every branch of the download route is dead in test:
+  ownership, 404-not-403, path containment, and the `nosniff` /
+  `application/octet-stream` headers. Replace the handler with a 302 to
+  `/uploads/...` and nothing fails — against an explicit `CLAUDE.md` invariant.
+- **TEST-31 — overdue is the app's only red signal and nothing asserts it appears.**
+  Invert the comparison at `src/app/page.tsx:67` and home reads "You're clear."
+  with an obligation three hours past its statutory deadline. All tests pass.
+
+---
+
+# Major
+
+## Correctness of guidance
+
+- **FLOW-34 — partial retrieval gets no guard, and the gap card vouches for it.**
+  `claude-service.ts:285-292`, `rag.ts:508-510`, `CoverageGapCard.tsx:40-44`.
+  The card says *"The guidance above uses the state and federal requirements
+  directly. **It is sound.**"* rendered from `categoriesWithoutLocalPolicy` alone
+  — regardless of whether any state or federal text was retrieved. Today, with
+  `mandatory_reporting` empty at every level, a bullying incident prints that
+  sentence under a DCYF deadline nothing in the system supports. `byCategory`
+  holds the distinction between "no local" and "nothing anywhere" and no
+  consumer reads it. **Fix:** split gaps by whether `byCategory[c]` is empty;
+  drop "It is sound" for categories with no authority at all.
+- **FLOW-36 — chat 503s intermittently once a transcript passes 20 messages.**
+  `route.ts:51-52`, `:90-92`; `claude-service.ts:319-325`. The window is a fixed
+  `take: 20` from the end, and summaries are filtered *after* the take, so the
+  first element is `assistant` whenever an odd number of rows was dropped. The
+  Anthropic API rejects a leading assistant message → 503 → *"I'm experiencing
+  technical difficulties"*. The user's message is persisted, flipping parity, so
+  it works next time and fails the time after. **Fix:** drop leading non-`user`
+  entries after building `priorMessages`.
+- **FLOW-37 — retrieval ranks by recency before relevance, and the current
+  question often contributes no search terms.** `rag.ts:258-261` takes the 24
+  most *recently created* matching chunks before scoring; `:312` builds the
+  query as `[incidentType, ...recentUserTurns, query]` and `:220-225` keeps the
+  first five words of ≥4 chars **in string order**, so on any follow-up turn the
+  administrator's actual question contributes nothing. Asking *"what is the
+  deadline to notify the parents?"* searches on `bullying` plus words from two
+  turns ago. This is the only live retrieval path (0 chunks embedded).
+- **FLOW-35 — a classification failure is permanent, silent, and indistinguishable
+  from a successful `other`.** The API call at `claude-service.ts:369-378` is
+  outside the `try`; `classifier.ts:43-47` returns `severity: 'low'` with **zero**
+  obligations; `:36-42` drops `reasoning`, so "Manual review required" is never
+  stored. The two fallbacks disagree (`claude-service.ts:400` says `medium` with
+  two actions). **Fix:** leave `incidentType` null on a thrown call so the next
+  turn retries; persist `reasoning`; reconcile the defaults.
+- **FLOW-40 — a truncated answer is stored and displayed as a complete one.**
+  `claude-service.ts:170-177` returns `stopReason`; `llm-service.ts:104-110`
+  drops it. Guidance hitting the 4096-token cap mid-list is filed as finished.
+- **FLOW-41 — the citation code is guessed from the title.**
+  `policy-sections.ts:174` takes the first 3–5-letter uppercase run anywhere in
+  the title. The seeded `SAU 24 School Bullying Investigation Form` yields
+  **"SAU §B"** — there is no policy called SAU. The model is explicitly told to
+  reproduce that reference verbatim. Same class as the `DISC-001` code a policy
+  was deactivated over. **Fix:** only accept the match in a code position.
+- **SPEC-41 — the summary path discards the coverage result.**
+  `incident-summary.ts:57` destructures only `response`. The one artefact that
+  goes into the file is the one output that never says a local policy is missing.
+- **SPEC-42 / FLOW-38 — citations and coverage vanish on reload.**
+  `api/chat/[incidentId]/route.ts:35-41` drops `metadata`, which
+  `api/chat/route.ts:196-203` stored. Re-open yesterday's chat and the guidance
+  appears with **no source ladder and no gap warning** — the strongest
+  presentation of the least supported answer. Same on the incident timeline.
+
+## Security
+
+- **SEC-19 — a session's role is never re-checked, and there is no way to revoke
+  access.** `auth.config.ts:80-86`, `:42-43`; `session.ts:41-48`. `token.role` is
+  written once at sign-in; `updateAge` refreshes `exp` on activity, so a stolen
+  or retained admin cookie stays alive indefinitely. A demoted administrator
+  keeps full admin. Deleting the row does not work either — `Incident.reporter`
+  and `AuditLog.user` are required relations with default `Restrict`. **There is
+  currently no mechanism to revoke a user's access.** **Fix:** add
+  `User.isActive`; re-read `{role, isActive}` in `requireUser()`.
+- **SEC-20 — no admin mutation writes an audit record.** Seven handlers, none
+  importing `recordAudit`. An attacker with an admin session rewrites the active
+  system prompt — which `claude-service.ts:196` loads for **every** consultation
+  — to suppress DCYF reporting, and `SystemPrompt` carries only `updatedAt`. The
+  district cannot determine who changed it, when, or what it said before. SEC-17
+  established this control for incidents; the highest-consequence mutation was
+  left out.
+- **SEC-22 — upload size is checked only after the body is fully in memory**
+  (SEC-10 still open). `request.formData()` precedes every limit check on all
+  three upload routes; `assertWithinSizeLimit` reads `file.size`, which exists
+  only once the part is materialised — its own docstring claims the opposite.
+  With no rate limiting, a few concurrent 2 GB bodies take the app down.
+- **SEC-23 — no rate limiting anywhere, including the unauthenticated credentials
+  endpoint** (SEC-11 still open). `rateLimitError()` is exported and imported by
+  nothing. `bcrypt.compare` at cost 12 is ~0.25s of *blocking* CPU, run
+  deliberately even for non-existent users, on a single event loop. Unbounded
+  online password guessing, and unbounded billed LLM spend post-auth.
+- **SEC-25 — retrieved policy text is concatenated into the *system* prompt
+  unfenced** (SEC-9 still open). `claude-service.ts:294-304`, `:327`. Text
+  extracted from an ingested document lands inside the `system` parameter,
+  carrying the same framing authority as the guard instructions above it.
+  Because a `mandatory_reporting` chunk is guaranteed in every consultation, one
+  poisoned chunk reaches essentially every answer. **Fix:** move `policyContext`
+  into a delimited user-turn block; strip the delimiters from chunk content.
+- **SEC-21 = SPEC-46 — `createdBy` is taken from the request body.**
+  `admin/prompts/route.ts:48`, `:63`. Verified verbatim. **This is the named
+  invariant** — `CLAUDE.md:49-50`: *"No route may read a user id from a body or
+  query string; that was a real vulnerability."* It is the last such route.
+  **Fix:** `createdBy: guard.user.id`.
+
+## Design and structure
+
+- **SPEC-43 = DEAD-57 — 21 CSS custom properties are referenced and defined
+  nowhere.** 122 references across six files. `globals.css` was deleted;
+  `theme.css` defines only `--color-*`, `--font-*`, `--radius-card|control`.
+  Verified: `--foreground` (32), `--muted-foreground` (31), `--secondary` (9),
+  `--background` (9), `--primary` (9), `--separator` (6), `--border` (5),
+  `--touch-target` (4), `--success` (4), `--radius` (3), `--destructive` (1),
+  and more. An undefined `var()` with no fallback invalidates the declaration.
+  Concretely: `chat/page.tsx:501` gives the user's own message bubble
+  `background: var(--secondary)` → **user turns render with no bubble at all**;
+  `ui/button.tsx:19` sets `min-h-[var(--touch-target)]` → the 44px minimum touch
+  target is absent on every `<Button>`; the destructive "End Chat" button paints
+  no background. **Violates** `CLAUDE.md`: *"There is no `globals.css` — it was
+  deleted, and its patterns should not come back."*
+- **SPEC-44 — colour is used for things that are not deadline states.**
+  `ClassificationChip.tsx:13-18` paints severity red/amber;
+  `incidents/[id]/page.tsx:412,437-439` paints every `upcoming` event amber
+  regardless of what `describeDeadline` returned, so an obligation due in three
+  weeks reads as needing attention today; `StateBlock.tsx:31-33` paints load
+  errors red. **Violates** *"Colour is earned. It means a deadline state and
+  nothing else."*
+- **TEST-32 — the e2e stub mis-routes a live test.** `claude-stub.ts:51-53`
+  dispatches on the substring `'title'`. In `chat-flow.spec.ts:276`, the
+  coverage-gap prompt interpolates *"…no district or school policy for them:
+  title_ix, discrimination"*, which contains `title`, so the stub returns
+  **"Playground Bullying Report"** as the compliance answer. That string is what
+  the test renders and persists. **Fix:** dispatch on unique sentinels; throw on
+  an unrecognised prompt.
+- **TEST-33 — `ensureCategoryRepresentation`'s most-local-authority preference is
+  unfalsifiable.** `rag.ts:376-392`. Every supplemented category in the fixture
+  has exactly one policy, so `!existing` short-circuits and the comparison never
+  runs. Flip `>` to `<` and the suite passes; in production that substitutes
+  34 CFR for JICK — *"passing a statute off as district procedure"*.
+- **TEST-34 — the one page full of time-derived text is the one page not checked
+  for hydration errors.** `smoke.spec.ts:37-48` registers only `pageerror`;
+  React #418 is a `console.error`. It also targets `incidents[0]`, which is the
+  emptiest incident in the database by the time it runs.
+- **TEST-35 — admin API authorization is untested.** Only the page redirect is
+  covered. Delete `requireRole('admin')` from the policy DELETE handler — any
+  reporter can remove the district's bullying procedure from every future
+  retrieval — and the suite is green.
+- **TEST-36 — `describeDeadline` renders nonexistent times.** Verified by
+  execution: 59m30s → **`in 60m`**; 23h59m30s → **`in 23h 60m`**.
+  `Math.round` can return 60 at both boundaries. On a ticking countdown in
+  tabular mono, the last 30 seconds of every hour display a time that does not
+  exist. `formatAbsolute` is untested entirely.
+- **TEST-37 — `fallbackSearch` is the only retrieval path that runs in test and
+  has no test.** `rag.ts:214-279`. Removing `mode: 'insensitive'` — documented as
+  dropping recall to zero on policy codes — fails nothing. The `isActive` filter
+  (the SPEC-5 fix) has no test. `word.length >= 4` means *"Was a 504 IEP due?"*
+  yields zero keywords and returns `[]` with no signal.
+- **TEST-38 — `extractJsonObject` and `classificationSchema` are untested.**
+  The stub returns bare valid JSON on every call, so neither the extractor's
+  brace-scanning nor the schema's rejection paths ever run.
+- **TEST-39 — `src/lib/errors.ts` has zero coverage**, including HTTP status
+  decided by substring-sniffing (`'API key'` → 503) and the `NODE_ENV ===
+  'development'` message suppression.
+- **TEST-40 — `reuseExistingServer` can run the whole suite against production.**
+  `playwright.config.ts:52-70`. The `env` block applies only to a server
+  Playwright *spawns*. Locally, anything already on 3100 is reused and the block
+  discarded — including `ANTHROPIC_BASE_URL`. `global-setup.ts:20` guards the
+  database it resets; it cannot guard a server it did not start. Billed calls and
+  test rows in real data, with the suite reporting normally.
+- **TEST-41 — order-dependent and retry-unsafe tests.** Four couplings, notably
+  `incident-management.spec.ts:76-95`, which closes the seeded incident and then
+  expects `Reopen Incident` — on a CI retry the incident is already closed and
+  the retry fails on a misleading locator timeout.
+
+## Duplication and structure
+
+- **DEAD-58 — three parallel policy-ingestion endpoints**, already divergent in
+  six ways (uploads directory, `.txt` handling, `effectiveDate` requiredness,
+  keywords, `chunksCreated`, error status). `ALLOWED_POLICY_EXTENSIONS` is
+  declared twice. **Fix:** one `src/lib/policy-ingest.ts`; three thin adapters.
+- **DEAD-59 — `policies:batch-upload` is documented in four places, has an empty
+  policy array, and posts with no session cookie** to a route that now requires
+  admin. It cannot work. `QUICK_START` calls it *"Method 1 (RECOMMENDED)"*.
+- **DEAD-60 — "overdue / today / this week" is computed twice on two clocks.**
+  Server at `api/obligations/route.ts:54-78`, client at `page.tsx:59-70`; the
+  tally comes from one and the headline from the other, on the same screen.
+- **DEAD-61 — "is this overdue?" has three implementations.** `deadline.ts:89-91`
+  is canonical and tested; `incidents/[id]/page.tsx:182` and
+  `api/obligations/route.ts:67` reimplement it untested.
+- **DEAD-62 — four incompatible resolutions of the uploads directory** across six
+  sites. Already misbehaving: `reindex-policies.ts:122` guards adoption with the
+  *scripts* variant, so a file written by `POST /api/policies` never matches and
+  **every re-index copies it again.** The attachment upload/download pair is a
+  verbatim 5-line duplicate; editing one alone makes student records unreadable.
+- **DEAD-63 — three near-identical error UIs**, all bypassing the design system,
+  one using a green primary button that `theme.css:85-87` records as deliberately
+  removed.
+- **DEAD-80 / REPO-18 — six root files are outside `npm run lint`**, including
+  `middleware.ts`, the deny-by-default auth gate. And `vitest.config.mts` is
+  outside `npm run typecheck` — `tsconfig.json`'s `**/*.ts` does not match
+  `.mts` (verified with `tsc --listFiles`). A typo there degrades to "0 tests
+  found", which `test:unit` reports as a pass.
+
+## Docs
+
+- **DOC-2** — README:199 gives a `DATABASE_URL` that CLAUDE.md:32-34 records as
+  failing with `P1010`.
+- **DOC-3** — `policies:batch-upload` documented as recommended in three files;
+  it 401s. See DEAD-59.
+- **DOC-4** — QUICK_START "Method 3: Web UI Upload" points at `/policies`, whose
+  upload control was deliberately deleted. Filed as SPEC-25 on 2026-08-31 and
+  never fixed.
+- **DOC-5 / DOC-6 / DOC-8** — POLICY_MAPPING and QUICK_START "System Status"
+  blocks claim the fabricated, deactivated `DISC-001` is loaded, mark a
+  nonexistent ACAC district policy "✅ Already uploaded", and claim "RAG
+  Working: ✅ Yes" against 0 embedded chunks. In a tool whose premise is not
+  asserting policy it did not retrieve, a status block listing a fabricated
+  policy code as loaded is the worst doc inaccuracy after DOC-1.
+- **DOC-7** — README overstates the admin UI's accepted file types; the picker is
+  `.txt,.md` while the API allows PDF/DOCX.
+
+---
+
+# Minor
+
+Recorded in full so they are not re-derived. Grouped; each carries file:line in
+the source reports.
+
+**Spec:** SPEC-45 (five uppercase sites outside `.eyebrow`), SPEC-47 (one
+`eslint-disable` remains; `no-explicit-any` is off project-wide, so the "no
+`any` widening" convention is unenforceable — ~16 `any`s, two on the
+classification path), SPEC-48 (`PATCH /api/obligations/[id]` can un-complete an
+obligation and erase `completedAt`), SPEC-49 (reading a full conversation writes
+no audit row — the most disclosive read in the app), SPEC-50 (navbar sends every
+role to `/admin/policies` and never to `/policies`).
+
+**Security:** SEC-24 (DNS rebinding — `safeFetchText` validates then reconnects
+by hostname), SEC-27 (`GET /api/policies` returns `content` and absolute
+`filePath` to any authenticated user), SEC-28 (nothing pins the session cookie
+`Secure` — needs verification against the deployed env), SEC-29 (`POST
+/api/policies` is an unused duplicate outside the `/api/admin` prefix).
+
+**Journeys:** FLOW-42 (guidance generated at temperature **1.0**; `||` converts
+an explicit 0 to 1.0), FLOW-43 (a 503 renders as the assistant speaking, with
+the General's avatar), FLOW-44 (the uncovered-category list is dropped in the
+zero-retrieval branch), FLOW-45 (`determineDataSensitivity` runs before
+classification, so every Title IX incident is recorded `INTERNAL` on its opening
+message), FLOW-46 (`DeadlineClock` colour is time-derived and unguarded),
+FLOW-47 (`in_progress` obligations display as done), FLOW-48 (a failed Generate
+Summary is swallowed silently), FLOW-49 (`POST /api/incidents` accepts a
+caller-supplied `incidentType`, so the incident can never be classified or gain
+obligations), FLOW-50 (model pinned to a dated snapshot; hardcoded token pricing).
+
+**Tests:** TEST-42 (asserts the stub's own canned text), TEST-43
+(`mobile.spec.ts:41-47` weakens its own 44px rule to `not.toBeNull()`), TEST-44
+(`splitPolicyIntoSectionedChunks` untested directly), TEST-45
+(`formatSectionCitation` renders `CFR §A` and `RSA §A` for seeded titles — see
+FLOW-41), TEST-46 (SourceLadder ordering unasserted), TEST-47 (`scripts/test-*`
+still carry a `test-` prefix implying coverage), TEST-48 (`llm-service.ts:32-76`
+is dead code that still swallows errors into filler text — the pattern removed
+directly below it).
+
+**Dead/duplicated:** DEAD-36…DEAD-79 in the source report. Deletion-eligible
+under the "no test or spec line" rule: `extractTextFromFile` (zero callers),
+`PolicyType` (whose `@deprecated … retained for existing imports` note is false
+— there are none), the orphaned chunker doc comment at `rag.ts:281-283`, the
+duplicated comment at `rag.ts:142-144`, the mispasted comment at
+`validation.ts:111-115`, the self-contradicting `chroma.ts:7-8`, five Next.js
+starter SVGs, and the `Navbar` scroll listener that toggles a class no
+stylesheet defines. Everything else is test-covered, spec-covered, or a repair
+rather than a deletion. Notable: **DEAD-73** — `attachments/upload/route.ts:14-18`
+states attachments *"are served from `public/`"*, the exact opposite of what the
+same file does 40 lines later and of the `CLAUDE.md` invariant.
+
+**Docs/repo:** DOC-9…DOC-20, REPO-17…REPO-22. Includes a 9.8 MB tracked policy
+PDF (~99% of the repo's non-`node_modules` content), an empty 34-byte
+`sample-policies/*.txt` stub, `.claude/settings.local.json` ignored only by the
+maintainer's *global* gitignore, three copies of the policy-upload instructions
+across README/QUICK_START/POLICY_MAPPING, and `scripts/verify-db.ts` reporting
+"8 tables" against a 9-model schema (it never checks `SystemPrompt`, the table
+the chat path reads on every request).
+
+**Verified clean and recorded so it is not re-checked:** all 18 API routes call
+`requireUser`/`requireRole` first; every by-id lookup is scoped and returns 404
+not 403; attachments live outside `public/` with containment assertions and
+correct headers; no `$queryRaw` anywhere; no `dangerouslySetInnerHTML`; no
+`NEXT_PUBLIC_*`; nothing sensitive is tracked in git; `useMounted` guards every
+time-derived render path; all `CLAUDE.md` test contracts exist in the source;
+the chat-path no-retrieval guard survives an admin-edited system prompt.
+
+---
+
+# Open questions — not resolved by guessing
+
+- **OQ-1 — is amber permitted for a coverage gap?** `CLAUDE.md` says colour means
+  *"a deadline state and nothing else"*; `theme.css:31` and the ux-redesign doc
+  record amber-for-gaps as a deliberate decision. Three components depend on it.
+  The two documents contradict each other and `CLAUDE.md` is binding.
+- **OQ-2 — which policy-ingestion endpoint is canonical?** (SPEC-34, still open.)
+  Three write paths, disagreeing on where a file lands on disk — which matters
+  for `policies:reindex`'s re-extraction.
+- **OQ-3 — what should an `other`-classified incident retrieve?** "Always
+  included" could mean "always in the filter" or "always in the retrieved set".
+  B3 proposes the latter; it changes the fix.
+- **OQ-4 — what may an admin-edited `SystemPrompt` weaken?** (SPEC-32, deferred.)
+  It replaces the in-code default for the chat path only — not `classifyIncident`
+  or `generateChatSummary` — so an admin editing "the system prompt" changes one
+  of three.
+- **OQ-5 — how should obligations behave when the library cannot support a
+  deadline? (B1.)** Suppress the obligation, show it without a countdown, or show
+  it marked unverified? Each is a different product. **This blocks the real fix
+  for the worst finding in this audit** and is the first thing to settle.

--- a/docs/audit/2026-09-01-work-completed.md
+++ b/docs/audit/2026-09-01-work-completed.md
@@ -16,7 +16,7 @@ All four pass from a clean build directory. CI runs exactly these.
 | `npm run typecheck` | 0 errors | 0 errors |
 | `npm run lint` | 0 errors, 3 warnings | 0 errors, 3 warnings |
 | `npm run build` | ✓ | ✓ |
-| `npm run test:unit` | 97 | **110** |
+| `npm run test:unit` | 97 | **114** |
 | `npm run test:e2e` | 52 | **53** |
 
 The 3 lint warnings are pre-existing and untouched (unused vars in
@@ -155,6 +155,36 @@ nothing. User message bubbles on `/chat` rendered with no background; the 44px
 minimum touch target was absent on every `<Button>`; the destructive "End Chat"
 variant painted nothing. Mapped to the tokens that exist and confirmed each
 resolves in the built CSS.
+
+## Review round (/bastion)
+
+Six findings, four of them correctness. All addressed.
+
+1. **The empty-extraction guard covered one of three ingestion paths.** The
+   worst of the six, and the same class of bug this audit is about: the
+   findings named "three parallel ingestion endpoints" as a major finding, and
+   the fix patched the handler that happened to be open. `POST /api/policies`
+   still created an active zero-chunk policy. The rule now lives once, in
+   `src/lib/uploads.ts`, and all three routes call it — as an `UploadError`
+   with 422, since the request is well-formed and the content is the problem.
+2. **A rejected upload left the file on disk.** The guard sat after
+   `writeFile`, so a refused upload orphaned the bytes with no `Policy` row —
+   violating a rule stated in a comment forty lines above it, in the same
+   function, about the same failure. Unlinked on that path now.
+3. **The PUT validated the facets and wrote the raw ones.** `facets.data` was
+   discarded. Equivalent today because `z.enum` does not transform, and a
+   silent bypass the moment it does.
+4. **`new Date(effectiveDate)` was still unguarded** in the object that had
+   just been given a schema for its neighbours. `Invalid Date` reached Prisma
+   and returned 500 for a bad request.
+5. **Commit batching.** One commit carried five unrelated concerns. The review
+   fixes are split into three.
+6. **Comments.** Seven blocks reconstructed how a bug was found rather than
+   what a reader needs at that line. Cut to the non-obvious why; the narrative
+   is already in this directory.
+
+Four new unit tests cover the shared guard, including whitespace-only input —
+which every truthiness check in those three routes lets through.
 
 ## Deferred, with reasons
 

--- a/docs/audit/2026-09-01-work-completed.md
+++ b/docs/audit/2026-09-01-work-completed.md
@@ -1,0 +1,212 @@
+# Audit remediation — 2026-09-01
+
+**Reading note.** This is the record of what was done. The findings are in
+[`2026-09-01-findings.md`](./2026-09-01-findings.md). The previous cycle is
+[`2026-08-31-work-completed.md`](./2026-08-31-work-completed.md).
+
+Branch `audit/2026-09-01`, cut from `dev` at `d62eb61`. 35 files changed,
++1376 / −186.
+
+## Gates
+
+All four pass from a clean build directory. CI runs exactly these.
+
+| | before | after |
+|---|---|---|
+| `npm run typecheck` | 0 errors | 0 errors |
+| `npm run lint` | 0 errors, 3 warnings | 0 errors, 3 warnings |
+| `npm run build` | ✓ | ✓ |
+| `npm run test:unit` | 97 | **110** |
+| `npm run test:e2e` | 52 | **53** |
+
+The 3 lint warnings are pre-existing and untouched (unused vars in
+`scripts/test-phase3.ts` and `scripts/test-rag.ts`).
+
+**No suppressions were introduced.** Verified by reading the whole diff:
+no `@ts-ignore`, no `@ts-expect-error`, no `eslint-disable`, no `any`
+widening, no `.skip`/`.only`. `tsconfig.json`, `eslint.config.mjs` and
+`.github/` are untouched.
+
+**One assertion was removed** — `expect(Array.isArray(obligations)).toBe(true)`
+in the cross-user obligation test, which was true for any successful GET. It
+is replaced by an assertion that the foreign obligation is absent from the
+caller's list, plus a real 404 on the foreign id. That is a strengthening; it
+is called out here because removing an assertion otherwise looks like exactly
+what this process forbids.
+
+## What was fixed
+
+Six blockers were found. **Five are fixed. One is a product decision and was
+not guessed** (B1, below).
+
+### The system no longer vouches for policy it does not have
+
+**B2** — `assessCoverage` counted any active policy row as coverage with no
+requirement that it have chunks. A row whose chunks are missing is invisible
+to retrieval, so counting it suppressed the very gap warning that says the
+library is empty. `policy-coverage.ts` already stated this rule for the
+offline report; the live path that decides what the administrator is told was
+more permissive than it. Production has been in exactly this state.
+
+**B3** — `categoriesForIncidentType` returns `[]` for `other` and for
+unclassified incidents. Correct as a search *filter*; it was also being used
+as the guaranteed set, so `ensureCategoryRepresentation` short-circuited and
+`assessCoverage` reported no gaps. An `other` incident retrieved no
+mandatory-reporting policy and raised no warning — and `other` is the
+classifier's own failure default, so that was the state an incident landed in
+precisely when the system knew least. Split into `guaranteedCategoriesFor`.
+
+**B4** — the summary prompt had no retrieval guard and still named `"JICK"`,
+`"ACAC"`, `"JLF"` as examples, which is what the guidance path was fixed for:
+with nothing retrieved they are the only codes the model has to reach for. The
+summary is persisted and rendered in the incident timeline, so it is the
+artefact most likely to be printed and filed. The guard is now a shared
+constant rather than inlined in one of its two callers.
+
+**FLOW-34** — the coverage card printed *"It is sound"* over guidance whose
+authority may not exist, because it rendered from `categoriesWithoutLocalPolicy`
+alone. `byCategory` carried the distinction between "only the local procedure
+is missing" and "the library holds nothing at any level", and no consumer read
+it. Card and prompt now separate the two.
+
+**B5** — no policy write path validated jurisdiction or category; all four
+defaulted the misses. Retrieval matches on category, so a typo makes a policy
+unfindable — and because `assessCoverage` queries the same column, the system
+then reports a coverage gap for an area the district has in fact loaded. A bad
+jurisdiction is worse: the excerpt is dropped from the model's context while
+`buildCitations` still lists it as a source. Also: an extraction producing no
+text no longer becomes an active policy, and the admin UI reports
+`chunksCreated` instead of saying "uploaded successfully" on any 2xx.
+
+**B6** — README described all six `scripts/test-*.ts` as needing a running
+server. Two import Prisma directly and create and delete `User`, `Incident`,
+`Conversation` and `Policy` rows. `.env` points at production. Both documents
+now name them.
+
+### Security
+
+**SEC-21** — `POST /api/admin/prompts` read `createdBy` from the request body.
+This is the named invariant, and it was the last such route. Also dropped the
+field from `createPromptSchema`, which encoded the same mistake.
+
+**SEC-20** — not one admin mutation wrote an audit record. All eight now do.
+The prompt update captures the previous content so a change to mandated-reporting
+advice is reconstructable, and the delete captures it before the row goes.
+
+### Tests that could not fail
+
+Three tests named an invariant and asserted something else. Each fix was
+verified by reintroducing the defect and watching the test fail:
+
+- **TEST-27** — dropping `incident: incidentScope(guard.user)` from
+  `obligations/[id]` lets any reporter discharge any obligation in the
+  district. Old test passed. New test: expected 404, received 200.
+- **TEST-28** — dropping `...incidentScope(guard.user)` from the `incidents/[id]`
+  GET and PATCH lets every reporter read and rewrite every incident in the
+  district. That is SEC-7. Old test passed, because it only re-checked the
+  *list*, which a different call site filters. New test: expected 404,
+  received 200.
+- **B2** — the fixture now seeds an active district policy with **no chunks**.
+  Reverting B2 makes `school_safety` gain phantom coverage and drop out of the
+  reported gaps; verified the assertion fails.
+
+The fixture could not express these tests: it seeded obligations only on the
+reporter's own incident, so no foreign row existed to attempt. The admin's
+incident now carries one, and `global-setup` writes both ids to
+`e2e/.auth/seed.json` — on disk, because Playwright runs specs in separate
+processes.
+
+**TEST-35** — admin API authorization had no test at all; only the page
+redirect was covered. Eight admin mutations are now asserted to return 403 for
+a reporter.
+
+**TEST-40** — `reuseExistingServer` meant the `webServer` env block, including
+`ANTHROPIC_BASE_URL`, was discarded whenever something was already on the port,
+so the suite could run against the real API and production data while
+reporting normally. `global-setup` guards the database it resets; it cannot
+guard a server it did not start.
+
+**TEST-32** — the e2e stub dispatched on the bare substring `'title'`, and the
+coverage-gap instruction interpolates a category list containing `title_ix`.
+One live test's compliance call was therefore returning a *title* string, which
+it rendered and persisted without noticing. Dispatch is now on wording unique
+to each prompt, and an unrecognised prompt throws.
+
+### Real bugs found while writing tests
+
+**TEST-36** — `describeDeadline` rendered times that do not exist. Each unit
+was rounded independently, so `Math.round` could return 60: 59m30s rendered
+`in 60m`, 23h59m30s rendered `in 23h 60m`. The last thirty seconds of every
+hour, on the app's most prominent element, set in tabular mono precisely so it
+reads cleanly. Every existing case sat comfortably inside its unit, so none
+crossed a carry.
+
+**FLOW-36** — chat 503'd intermittently once a transcript passed 20 messages.
+The history window is a fixed row count from the end, so its first entry is an
+assistant turn whenever an odd number of rows was dropped — and the API rejects
+a leading assistant message. The failure alternated, because the rejected turn
+persisted the user message and flipped the parity. Reported by a user, this
+would look like "it keeps erroring".
+
+**SPEC-43** — 120 references to 13 CSS custom properties that no stylesheet
+defines, left behind when `globals.css` was deleted. Verified against the built
+stylesheet: none of them appear in it, so every declaration using them did
+nothing. User message bubbles on `/chat` rendered with no background; the 44px
+minimum touch target was absent on every `<Button>`; the destructive "End Chat"
+variant painted nothing. Mapped to the tokens that exist and confirmed each
+resolves in the built CSS.
+
+## Deferred, with reasons
+
+**B1 — obligation deadlines are invented by the model.** The worst finding in
+the audit. `classifyIncident` is called with two arguments, so its
+`policyContext` parameter is `undefined` and the prompt that produces every
+`dueInHours` contains no policy text; the model is asked to recall New
+Hampshire law. `ComplianceAction` has no `policyId` and no `citation`, so
+nothing can be reconciled afterwards.
+
+The fix is a two-phase classification that re-derives obligations after
+retrieval and drops any deadline it cannot attribute to an excerpt — but that
+requires deciding what the product does when the library cannot support a
+deadline: suppress the obligation, show it without a countdown, or show it
+marked unverified. Each is a different product. **Logged as OQ-5 and not
+guessed.**
+
+What *was* done: the two UI strings that claimed the deadline came from the
+policy no longer say so. The home empty state and the thin-library banner now
+tell the administrator to confirm each deadline against the cited policy.
+`ObligationRow` already renders its `AuthorityChip` conditionally; it simply
+never has a citation to show.
+
+**Deferred majors**, recorded in the findings and untouched here: SEC-19 (no
+way to revoke a user's access — needs a schema change and a product decision
+about session lifetime), SEC-22 (upload size checked after buffering, SEC-10
+still open), SEC-23 (no rate limiting, SEC-11 still open), SEC-25 (retrieved
+policy text concatenated into the *system* prompt unfenced — the prompt-injection
+surface), FLOW-37 (retrieval ranks by recency before relevance and the current
+question often contributes no search terms), FLOW-35, FLOW-40, FLOW-41,
+SPEC-41, SPEC-42/FLOW-38, DEAD-58 through DEAD-63, DEAD-80.
+
+**Not deleted, per the standing rule.** Every dead-code finding whose behaviour
+is not covered by a test or a spec line was recorded and left. Eight items were
+identified as unambiguously removable; none were removed in this pass, because
+removal is not what any blocker needed and the rule is there to stop exactly
+that kind of opportunistic change. They are listed at the end of the findings.
+
+## Open questions
+
+Five, unresolved and not guessed. **OQ-5 blocks the real fix for B1** and is
+the first thing to settle. OQ-1 (is amber permitted for a coverage gap?) is a
+direct contradiction between `CLAUDE.md` and `theme.css` plus the ux-redesign
+doc; `CLAUDE.md` is binding, so the code follows it today and the documents
+should be reconciled either way.
+
+## Known remaining work
+
+The docs findings (DOC-3 through DOC-20, REPO-17 through REPO-22) are largely
+untouched: `POLICY_MAPPING.md` and `QUICK_START_POLICY_UPLOAD.md` still
+advertise the deactivated fabricated `DISC-001` as loaded, still point Method 3
+at a page whose upload control was deleted, and still call
+`policies:batch-upload` recommended when it cannot authenticate. These mislead
+an operator but do not change what the running system does, so they were
+sequenced behind the blockers and the cycle cap was reached first.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -154,6 +154,38 @@ All 11 JICK sections (A–K) parse, 9 of them carrying their RSA reference.
 
 ---
 
+### Audit 2026-09-01 — **done, with one blocker deferred**
+
+Six parallel read-only passes; 142 findings, 6 blockers. Five fixed. See
+[`docs/audit/2026-09-01-findings.md`](./audit/2026-09-01-findings.md) and
+[`-work-completed.md`](./audit/2026-09-01-work-completed.md).
+
+The one not fixed is the important one, and it changes what step 6 below is
+for: **obligation deadlines are produced by a classification call that is
+never shown a policy.** `classifyIncident` is invoked with two arguments, so
+its `policyContext` parameter is undefined and the model is asked to recall
+New Hampshire law. Until that is fixed, every countdown in the product is the
+model's guess, and `ComplianceAction` has no `policyId` to reconcile it
+against.
+
+The fix needs a product decision first — **OQ-5: what should the product do
+when the library cannot support a deadline?** Suppress the obligation, show it
+without a countdown, or show it marked unverified. Settle that and the
+two-phase re-classification is straightforward. The UI has been corrected in
+the meantime so it no longer claims the deadline came from the policy.
+
+Three other things that were true and are no longer:
+
+- A policy row with no chunks used to *cancel* the coverage gap for its
+  category, so one bad upload silently removed a safety warning.
+- An `other`-classified incident — the classifier's own failure default —
+  retrieved no mandatory-reporting policy and reported no gap.
+- The cross-user authorization tests attempted ids that do not exist, so
+  deleting `incidentScope` from the incident and obligation routes left the
+  suite green. That is SEC-7 with a passing test.
+
+---
+
 ## Next — gated on real use
 
 ### 6. Run a real incident end to end, and watch it — *maintainer*

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -197,7 +197,13 @@ test.describe('Local policy coverage', () => {
     // school_safety and emergency_operations have no policy at all in the
     // fixture set; discipline and mandatory_reporting do, and must not be
     // reported as gaps.
+    //
+    // school_safety carries a second job: the fixture seeds an active district
+    // school_safety policy with NO chunks. Retrieval can never return it, so it
+    // must not cancel this gap. Drop the `chunks: { some: {} }` predicate from
+    // assessCoverage and this assertion fails -- which is the point. (B2)
     expect(body.coverage.categoriesWithoutLocalPolicy).toContain('school_safety');
+    expect(body.coverage.byCategory.school_safety).toEqual([]);
     expect(body.coverage.categoriesWithoutLocalPolicy).toContain('emergency_operations');
     expect(body.coverage.categoriesWithoutLocalPolicy).not.toContain('discipline');
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,3 +1,4 @@
+import { writeFileSync, mkdirSync } from 'fs';
 import type { Server } from 'http';
 import { resetDatabase } from './support/seed';
 import { startClaudeStub } from './support/claude-stub';
@@ -23,6 +24,12 @@ export default async function globalSetup() {
     );
   }
 
-  await resetDatabase();
+  const seeded = await resetDatabase();
+
+  // Handed to the specs on disk rather than through a global: Playwright runs
+  // them in separate processes, so a module-level value would not survive.
+  mkdirSync('e2e/.auth', { recursive: true });
+  writeFileSync('e2e/.auth/seed.json', JSON.stringify(seeded, null, 2));
+
   globalThis.__claudeStub = await startClaudeStub(CLAUDE_STUB_PORT);
 }

--- a/e2e/incident-management.spec.ts
+++ b/e2e/incident-management.spec.ts
@@ -1,4 +1,13 @@
 import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+
+/**
+ * Ids of rows owned by the *other* user, written by global-setup. A test that
+ * must prove it cannot reach something needs the real id of that something.
+ */
+function seededIds(): { adminIncidentId: string; adminObligationId: string } {
+  return JSON.parse(readFileSync('e2e/.auth/seed.json', 'utf8'));
+}
 
 /**
  * Seeded fixtures make every assertion unconditional.
@@ -107,6 +116,22 @@ test.describe('Incident management', () => {
   });
 
   test('does not expose another user\'s incident by id', async ({ page }) => {
+    // This used to assert only that the *list* omitted it, which the test above
+    // already covers -- so deleting incidentScope from the by-id handlers left
+    // it green while every reporter could read and rewrite every incident in
+    // the district. That is SEC-7. Attempt the id itself. (TEST-28)
+    const { adminIncidentId } = seededIds();
+
+    const read = await page.request.get(`/api/incidents/${adminIncidentId}`);
+    expect(read.status()).toBe(404);
+
+    const write = await page.request.patch(`/api/incidents/${adminIncidentId}`, {
+      data: { status: 'closed' },
+    });
+    expect(write.status()).toBe(404);
+
+    // 404 and not 403: an id must not be confirmed to someone who may not read
+    // it. And the list must still omit it.
     const all = await page.request.get('/api/incidents');
     const { incidents } = await all.json();
     expect(incidents.some((i: { title: string }) => i.title === ADMIN_ONLY)).toBe(false);
@@ -153,15 +178,24 @@ test.describe('Obligation queue', () => {
   });
 
   test('a reporter cannot discharge another user\'s obligation', async ({ page }) => {
-    const list = await page.request.get('/api/obligations');
-    const { obligations } = await list.json();
-    // Every obligation returned is on an incident this user filed; an id from
-    // outside that scope must not be updatable.
-    const foreign = await page.request.patch('/api/obligations/does-not-exist-id', {
+    // This used to PATCH 'does-not-exist-id', which 404s whether or not the
+    // handler scopes through the incident -- so removing that scope, and
+    // letting any user discharge any obligation in the district, left the test
+    // green. The fixture now seeds an obligation on the admin's incident so
+    // there is a real foreign row to attempt. (TEST-27)
+    const { adminObligationId } = seededIds();
+
+    const foreign = await page.request.patch(`/api/obligations/${adminObligationId}`, {
       data: { status: 'completed' },
     });
     expect(foreign.status()).toBe(404);
-    expect(Array.isArray(obligations)).toBe(true);
+
+    // It is not enough that the call was refused: the row must be untouched.
+    const list = await page.request.get('/api/obligations');
+    const { obligations } = await list.json();
+    expect(
+      obligations.some((o: { id: string }) => o.id === adminObligationId)
+    ).toBe(false);
   });
 
   test('shows the empty state when nothing is outstanding', async ({ page }) => {
@@ -258,7 +292,14 @@ test.describe('Incident summary', () => {
   });
 
   test('does not summarise another user\'s incident', async ({ page }) => {
-    const gen = await page.request.post('/api/incidents/does-not-exist/summary');
+    // A real foreign id, not a nonexistent one: generating a summary reads the
+    // whole transcript, so an unscoped handler here discloses the most of any
+    // route in the app. (TEST-28)
+    const { adminIncidentId } = seededIds();
+    const gen = await page.request.post(`/api/incidents/${adminIncidentId}/summary`);
     expect(gen.status()).toBe(404);
+
+    const missing = await page.request.post('/api/incidents/does-not-exist/summary');
+    expect(missing.status()).toBe(404);
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -32,6 +32,36 @@ test.describe('Navigation', () => {
     await expect(page.getByRole('heading', { name: 'Policy Management' })).toHaveCount(0);
   });
 
+  test('a reporter cannot call the admin API, only the admin pages were guarded', async ({
+    page,
+  }) => {
+    // The page redirect above was the only admin coverage there was. Deleting
+    // requireRole('admin') from the policy DELETE handler lets any reporter
+    // remove the district's bullying procedure from every future retrieval,
+    // and nothing failed. These are the nine handlers that guard actually
+    // holds. (TEST-35)
+    const attempts: [('post' | 'put' | 'patch' | 'delete'), string][] = [
+      ['post', '/api/admin/policies'],
+      ['put', '/api/admin/policies/any-id'],
+      ['delete', '/api/admin/policies/any-id'],
+      ['post', '/api/admin/policies/upload'],
+      ['post', '/api/admin/prompts'],
+      ['put', '/api/admin/prompts/any-id'],
+      ['delete', '/api/admin/prompts/any-id'],
+      ['post', '/api/policies'],
+    ];
+
+    for (const [method, url] of attempts) {
+      const response = await page.request[method](url, { data: {} });
+      // 403, not 404: the caller is authenticated and the route exists — it is
+      // the role that is insufficient. Scoping hides rows; roles refuse verbs.
+      expect(
+        response.status(),
+        `${method.toUpperCase()} ${url} should be refused for a reporter`
+      ).toBe(403);
+    }
+  });
+
   test('signing out ends the session', async ({ page, context }) => {
     await page.goto('/');
     await page.getByText('Settings').click();

--- a/e2e/support/claude-stub.ts
+++ b/e2e/support/claude-stub.ts
@@ -48,12 +48,10 @@ function replyFor(body: StubRequest): string {
     .map(m => m.content)
     .join(' ');
 
-  // Dispatch on wording unique to each prompt, not on common words. Matching
-  // the bare substring 'title' mis-routed a live test: the coverage-gap
-  // instruction interpolates the category list, which contains 'title_ix', so
-  // the compliance branch returned a *title* string and the test asserting on
-  // it never noticed. Any prompt that reaches neither branch is now loud
-  // instead of silently answering as something else. (TEST-32)
+  // Unique wording, not common words: 'title' also appears in the coverage-gap
+  // instruction via 'title_ix', which routed a compliance call to the title
+  // branch. An unmatched prompt throws rather than answering as something
+  // else. (TEST-32)
   if (system.includes('school incident classification expert')) {
     return classificationJson(userText);
   }

--- a/e2e/support/claude-stub.ts
+++ b/e2e/support/claude-stub.ts
@@ -48,9 +48,24 @@ function replyFor(body: StubRequest): string {
     .map(m => m.content)
     .join(' ');
 
-  if (system.includes('classification expert')) return classificationJson(userText);
-  // generateIncidentTitle asks for a short title and nothing else.
-  if (system.includes('title')) return 'Playground Bullying Report';
+  // Dispatch on wording unique to each prompt, not on common words. Matching
+  // the bare substring 'title' mis-routed a live test: the coverage-gap
+  // instruction interpolates the category list, which contains 'title_ix', so
+  // the compliance branch returned a *title* string and the test asserting on
+  // it never noticed. Any prompt that reaches neither branch is now loud
+  // instead of silently answering as something else. (TEST-32)
+  if (system.includes('school incident classification expert')) {
+    return classificationJson(userText);
+  }
+  if (system.includes('concise, descriptive titles for school incident reports')) {
+    return 'Playground Bullying Report';
+  }
+  if (system.includes('school district attorney reviewing an incident consultation')) {
+    return 'SUMMARY: consultation summary for the incident file.';
+  }
+  if (!system.includes('Available Policy Context:')) {
+    throw new Error(`claude-stub: unrecognised system prompt: ${system.slice(0, 160)}`);
+  }
 
   // Echo which jurisdictions appeared in the injected policy context, and
   // whether the coverage-gap instruction was present, so tests can assert on

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -114,6 +114,17 @@ export async function resetDatabase(): Promise<void> {
       },
     ];
 
+    // Active, district, school_safety -- and deliberately given NO chunks below.
+    // Retrieval can never return it, so it must not count as coverage. This is
+    // the production state a failed re-index leaves behind, and counting it
+    // suppressed the gap warning that says the library is empty. (B2)
+    const unchunked = {
+      title: 'Policy EBCA: Crisis Response (indexing incomplete)',
+      jurisdiction: 'district',
+      category: 'school_safety',
+      content: 'District procedure: unavailable -- this policy has not been indexed.',
+    };
+
     for (const p of policies) {
       const created = await prisma.policy.create({
         data: {
@@ -138,6 +149,17 @@ export async function resetDatabase(): Promise<void> {
         })),
       });
     }
+
+    await prisma.policy.create({
+      data: {
+        title: unchunked.title,
+        content: unchunked.content,
+        jurisdiction: unchunked.jurisdiction,
+        category: unchunked.category,
+        effectiveDate: new Date('2024-01-01'),
+        isActive: true,
+      },
+    });
 
     // One open incident owned by the reporter, one closed, and one owned by
     // the admin so cross-user access can be asserted.

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -18,7 +18,13 @@ export const TEST_USERS = {
  * fully parallel, so an empty-state test and an incident-creating test raced
  * each other. (TEST-21)
  */
-export async function resetDatabase(): Promise<void> {
+/** Ids a test needs to attempt access it must not be granted. */
+export interface SeededIds {
+  adminIncidentId: string;
+  adminObligationId: string;
+}
+
+export async function resetDatabase(): Promise<SeededIds> {
   execSync('npx prisma migrate deploy', { stdio: 'inherit' });
 
   const prisma = new PrismaClient();
@@ -209,7 +215,11 @@ export async function resetDatabase(): Promise<void> {
         closedAt: new Date(),
       },
     });
-    await prisma.incident.create({
+    // The admin's incident carries an obligation of its own. Without one there
+    // is no foreign row for a reporter to attempt, so the cross-user tests had
+    // to PATCH an id that does not exist -- which 404s whether or not scoping
+    // is applied, and so could not fail. (TEST-27, TEST-28)
+    const adminIncident = await prisma.incident.create({
       data: {
         title: 'Title IX: Admin-only incident',
         description: 'Only the admin filed this one.',
@@ -217,8 +227,22 @@ export async function resetDatabase(): Promise<void> {
         severity: 'critical',
         incidentType: 'title_ix',
         reporterId: admin.id,
+        complianceActions: {
+          create: {
+            actionType: 'notification',
+            description: 'Notify the Title IX coordinator',
+            status: 'pending',
+            dueDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+          },
+        },
       },
+      include: { complianceActions: true },
     });
+
+    return {
+      adminIncidentId: adminIncident.id,
+      adminObligationId: adminIncident.complianceActions[0].id,
+    };
   } finally {
     await prisma.$disconnect();
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,7 +52,13 @@ export default defineConfig({
   webServer: {
     command: 'npm run build && npm start',
     url: BASE_URL,
-    reuseExistingServer: !process.env.CI,
+    // Never reuse. The env block below applies only to a server Playwright
+    // starts, so reusing one already on this port silently discards
+    // ANTHROPIC_BASE_URL and runs the whole suite against the real API and
+    // whatever DATABASE_URL that process was given -- and .env points at
+    // production. global-setup guards the database it resets; it cannot guard
+    // a server it did not start. (TEST-40)
+    reuseExistingServer: false,
     timeout: 180_000,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,17 +4,17 @@ import Navbar from '@/components/Navbar';
 
 export default function AboutPage() {
   return (
-    <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <Navbar />
       <div className="max-w-4xl mx-auto px-6 py-12">
-        <h1 className="text-4xl font-semibold mb-8" style={{ color: 'var(--foreground)' }}>
+        <h1 className="text-4xl font-semibold mb-8" style={{ color: 'var(--color-text)' }}>
           About
         </h1>
 
-        <div className="space-y-6" style={{ color: 'var(--foreground)' }}>
+        <div className="space-y-6" style={{ color: 'var(--color-text)' }}>
           <section>
             <h2 className="text-2xl font-semibold mb-4">School Compliance AI</h2>
-            <p className="text-lg" style={{ color: 'var(--muted-foreground)' }}>
+            <p className="text-lg" style={{ color: 'var(--color-text-muted)' }}>
               An intelligent assistant designed to help school administrators navigate complex compliance scenarios
               with confidence and clarity.
             </p>
@@ -22,7 +22,7 @@ export default function AboutPage() {
 
           <section>
             <h2 className="text-2xl font-semibold mb-4">Features</h2>
-            <ul className="list-disc list-inside space-y-2 text-lg" style={{ color: 'var(--muted-foreground)' }}>
+            <ul className="list-disc list-inside space-y-2 text-lg" style={{ color: 'var(--color-text-muted)' }}>
               <li>AI-powered policy analysis and recommendations</li>
               <li>Real-time compliance guidance based on your district policies</li>
               <li>Customizable system prompts for tailored responses</li>
@@ -33,14 +33,14 @@ export default function AboutPage() {
 
           <section>
             <h2 className="text-2xl font-semibold mb-4">Technology</h2>
-            <p className="text-lg" style={{ color: 'var(--muted-foreground)' }}>
+            <p className="text-lg" style={{ color: 'var(--color-text-muted)' }}>
               Powered by Claude AI (Anthropic) for intelligent, context-aware responses that help you make informed
               decisions while maintaining compliance with school policies and regulations.
             </p>
           </section>
 
-          <section className="pt-8 border-t" style={{ borderColor: 'var(--separator)' }}>
-            <p className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
+          <section className="pt-8 border-t" style={{ borderColor: 'var(--color-line)' }}>
+            <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
               Version 1.0.0
             </p>
           </section>

--- a/src/app/admin/policies/page.tsx
+++ b/src/app/admin/policies/page.tsx
@@ -206,21 +206,21 @@ export default function PoliciesPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+      <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
         <Navbar />
         <div className="flex items-center justify-center h-screen">
-          <p className="body-text" style={{ color: 'var(--muted-foreground)' }}>Loading...</p>
+          <p className="body-text" style={{ color: 'var(--color-text-muted)' }}>Loading...</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <Navbar />
       <div className="container mx-auto px-4 py-8 max-w-7xl">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="heading-xl" style={{ color: 'var(--foreground)' }}>Policy Management</h1>
+          <h1 className="heading-xl" style={{ color: 'var(--color-text)' }}>Policy Management</h1>
           <Button onClick={() => setShowUploadModal(true)}>
             <Upload size={20} style={{ marginRight: 'var(--spacing-2)' }} />
             Upload Policy
@@ -230,14 +230,14 @@ export default function PoliciesPage() {
         {/* Policies List */}
         <div className="card">
           <div style={{ padding: 'var(--spacing-6)' }}>
-            <h2 className="heading-md mb-4" style={{ color: 'var(--foreground)' }}>
+            <h2 className="heading-md mb-4" style={{ color: 'var(--color-text)' }}>
               Current Policies ({policies.length})
             </h2>
 
             {policies.length === 0 ? (
               <div className="text-center" style={{ padding: 'var(--spacing-8) 0' }}>
-                <FileText size={48} className="mx-auto mb-4" style={{ color: 'var(--muted-foreground)' }} />
-                <p className="body-text mb-4" style={{ color: 'var(--muted-foreground)' }}>No policies uploaded yet</p>
+                <FileText size={48} className="mx-auto mb-4" style={{ color: 'var(--color-text-muted)' }} />
+                <p className="body-text mb-4" style={{ color: 'var(--color-text-muted)' }}>No policies uploaded yet</p>
                 <Button onClick={() => setShowUploadModal(true)}>
                   <Upload size={20} style={{ marginRight: 'var(--spacing-2)' }} />
                   Upload Your First Policy
@@ -258,10 +258,10 @@ export default function PoliciesPage() {
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="heading-md" style={{ color: 'var(--foreground)' }}>{policy.title}</h3>
+                          <h3 className="heading-md" style={{ color: 'var(--color-text)' }}>{policy.title}</h3>
                           {policy.isActive && (
                             <span className="badge" style={{
-                              background: 'var(--success)',
+                              background: 'var(--color-met)',
                               color: 'white',
                               fontSize: '12px'
                             }}>
@@ -270,7 +270,7 @@ export default function PoliciesPage() {
                           )}
                         </div>
 
-                        <div className="flex flex-wrap gap-4 caption" style={{ color: 'var(--muted-foreground)' }}>
+                        <div className="flex flex-wrap gap-4 caption" style={{ color: 'var(--color-text-muted)' }}>
                           <div className="flex items-center gap-1">
                             <Tag size={14} />
                             <span className="capitalize">{policy.jurisdiction}</span>
@@ -315,11 +315,11 @@ export default function PoliciesPage() {
           }}>
             <div className="card max-w-2xl w-full max-h-[90vh] overflow-y-auto">
               <div style={{ padding: 'var(--spacing-6)' }}>
-                <h2 className="heading-lg mb-6" style={{ color: 'var(--foreground)' }}>Upload Policy</h2>
+                <h2 className="heading-lg mb-6" style={{ color: 'var(--color-text)' }}>Upload Policy</h2>
 
                 {/* Upload Method Selection */}
                 <div className="mb-6">
-                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Upload Method
                   </label>
                   <div className="grid grid-cols-3 gap-2">
@@ -327,13 +327,13 @@ export default function PoliciesPage() {
                       onClick={() => setUploadMethod('text')}
                       className={`transition-colors ${
                         uploadMethod === 'text'
-                          ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
-                          : 'bg-[var(--secondary)] text-[var(--foreground)] hover:bg-[var(--secondary-hover)]'
+                          ? 'bg-[var(--color-text)] text-[var(--color-bg)]'
+                          : 'bg-[var(--color-input)] text-[var(--color-text)] hover:bg-[var(--color-line)]'
                       }`}
                       style={{
                         padding: 'var(--spacing-3)',
-                        borderRadius: 'var(--radius)',
-                        border: uploadMethod === 'text' ? 'none' : '0.5px solid var(--border)'
+                        borderRadius: 'var(--radius-control)',
+                        border: uploadMethod === 'text' ? 'none' : '0.5px solid var(--color-line)'
                       }}
                     >
                       <FileText size={20} className="mx-auto mb-1" />
@@ -343,13 +343,13 @@ export default function PoliciesPage() {
                       onClick={() => setUploadMethod('url')}
                       className={`transition-colors ${
                         uploadMethod === 'url'
-                          ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
-                          : 'bg-[var(--secondary)] text-[var(--foreground)] hover:bg-[var(--secondary-hover)]'
+                          ? 'bg-[var(--color-text)] text-[var(--color-bg)]'
+                          : 'bg-[var(--color-input)] text-[var(--color-text)] hover:bg-[var(--color-line)]'
                       }`}
                       style={{
                         padding: 'var(--spacing-3)',
-                        borderRadius: 'var(--radius)',
-                        border: uploadMethod === 'url' ? 'none' : '0.5px solid var(--border)'
+                        borderRadius: 'var(--radius-control)',
+                        border: uploadMethod === 'url' ? 'none' : '0.5px solid var(--color-line)'
                       }}
                     >
                       <LinkIcon size={20} className="mx-auto mb-1" />
@@ -359,13 +359,13 @@ export default function PoliciesPage() {
                       onClick={() => setUploadMethod('file')}
                       className={`transition-colors ${
                         uploadMethod === 'file'
-                          ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
-                          : 'bg-[var(--secondary)] text-[var(--foreground)] hover:bg-[var(--secondary-hover)]'
+                          ? 'bg-[var(--color-text)] text-[var(--color-bg)]'
+                          : 'bg-[var(--color-input)] text-[var(--color-text)] hover:bg-[var(--color-line)]'
                       }`}
                       style={{
                         padding: 'var(--spacing-3)',
-                        borderRadius: 'var(--radius)',
-                        border: uploadMethod === 'file' ? 'none' : '0.5px solid var(--border)'
+                        borderRadius: 'var(--radius-control)',
+                        border: uploadMethod === 'file' ? 'none' : '0.5px solid var(--color-line)'
                       }}
                     >
                       <Upload size={20} className="mx-auto mb-1" />
@@ -376,7 +376,7 @@ export default function PoliciesPage() {
 
                 {/* Title */}
                 <div className="mb-4">
-                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Policy Title *
                   </label>
                   <input
@@ -390,7 +390,7 @@ export default function PoliciesPage() {
 
                 {/* Jurisdiction: where the policy comes from */}
                 <div className="mb-4">
-                  <label htmlFor="jurisdiction" className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label htmlFor="jurisdiction" className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Jurisdiction *
                   </label>
                   <select
@@ -405,14 +405,14 @@ export default function PoliciesPage() {
                       </option>
                     ))}
                   </select>
-                  <p className="caption mt-1" style={{ color: 'var(--muted-foreground)' }}>
+                  <p className="caption mt-1" style={{ color: 'var(--color-text-muted)' }}>
                     Who issued it. District and school policies should implement the federal and state requirements.
                   </p>
                 </div>
 
                 {/* Category: what the policy is about */}
                 <div className="mb-4">
-                  <label htmlFor="category" className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label htmlFor="category" className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Category *
                   </label>
                   <select
@@ -427,14 +427,14 @@ export default function PoliciesPage() {
                       </option>
                     ))}
                   </select>
-                  <p className="caption mt-1" style={{ color: 'var(--muted-foreground)' }}>
+                  <p className="caption mt-1" style={{ color: 'var(--color-text-muted)' }}>
                     What it covers. Incident classification matches on this to decide which policies apply.
                   </p>
                 </div>
 
                 {/* Effective Date */}
                 <div className="mb-4">
-                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Effective Date *
                   </label>
                   <input
@@ -447,7 +447,7 @@ export default function PoliciesPage() {
 
                 {/* Keywords */}
                 <div className="mb-4">
-                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                  <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                     Keywords (comma-separated)
                   </label>
                   <input
@@ -462,7 +462,7 @@ export default function PoliciesPage() {
                 {/* Content Input (varies by method) */}
                 {uploadMethod === 'text' && (
                   <div className="mb-4">
-                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                       Policy Content *
                     </label>
                     <textarea
@@ -483,7 +483,7 @@ export default function PoliciesPage() {
 
                 {uploadMethod === 'url' && (
                   <div className="mb-4">
-                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                       Policy URL *
                     </label>
                     <input
@@ -493,7 +493,7 @@ export default function PoliciesPage() {
                       placeholder="https://example.com/policy.txt"
                       className="field body-text"
                     />
-                    <p className="caption mt-2" style={{ color: 'var(--muted-foreground)' }}>
+                    <p className="caption mt-2" style={{ color: 'var(--color-text-muted)' }}>
                       URL must point to a text-based document
                     </p>
                   </div>
@@ -501,7 +501,7 @@ export default function PoliciesPage() {
 
                 {uploadMethod === 'file' && (
                   <div className="mb-4">
-                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                       Policy File *
                     </label>
                     <input
@@ -510,7 +510,7 @@ export default function PoliciesPage() {
                       onChange={(e) => setFile(e.target.files?.[0] || null)}
                       className="field body-text"
                     />
-                    <p className="caption mt-2" style={{ color: 'var(--muted-foreground)' }}>
+                    <p className="caption mt-2" style={{ color: 'var(--color-text-muted)' }}>
                       Supported formats: .txt, .md
                     </p>
                   </div>

--- a/src/app/admin/policies/page.tsx
+++ b/src/app/admin/policies/page.tsx
@@ -25,6 +25,28 @@ interface Policy {
   };
 }
 
+/**
+ * Report what an upload actually achieved.
+ *
+ * The route computes and returns `chunksCreated`; all three call sites threw it
+ * away and said "uploaded successfully" on any 2xx. A policy with no chunks is
+ * invisible to retrieval, so that message was wrong in exactly the case the
+ * operator most needed to know about. (B5)
+ */
+function reportUpload(data: { chunksCreated?: number }) {
+  const chunks = data.chunksCreated;
+  if (chunks === undefined) {
+    alert('Policy uploaded.');
+    return;
+  }
+  alert(
+    chunks > 0
+      ? `Policy uploaded and indexed into ${chunks} searchable chunk${chunks === 1 ? '' : 's'}.`
+      : 'Policy uploaded, but it produced no searchable text, so retrieval cannot return it. ' +
+        'Check the document and re-upload.'
+  );
+}
+
 export default function PoliciesPage() {
   const [policies, setPolicies] = useState<Policy[]>([]);
   const [loading, setLoading] = useState(true);
@@ -93,7 +115,7 @@ export default function PoliciesPage() {
           throw new Error(data.error || 'Failed to upload policy');
         }
 
-        alert('Policy uploaded successfully');
+        reportUpload(await response.json());
       } else if (uploadMethod === 'url') {
         // Upload from URL
         if (!url.trim()) {
@@ -119,7 +141,7 @@ export default function PoliciesPage() {
           throw new Error(data.error || 'Failed to upload policy');
         }
 
-        alert('Policy uploaded successfully');
+        reportUpload(await response.json());
       } else if (uploadMethod === 'file') {
         // Upload file
         if (!file) {
@@ -145,7 +167,7 @@ export default function PoliciesPage() {
           throw new Error(data.error || 'Failed to upload policy');
         }
 
-        alert('Policy uploaded successfully');
+        reportUpload(await response.json());
       }
 
       // Reset form

--- a/src/app/admin/prompt/page.tsx
+++ b/src/app/admin/prompt/page.tsx
@@ -180,21 +180,21 @@ export default function PromptEditorPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+      <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
         <Navbar />
         <div className="flex items-center justify-center h-screen">
-          <p className="body-text" style={{ color: 'var(--muted-foreground)' }}>Loading...</p>
+          <p className="body-text" style={{ color: 'var(--color-text-muted)' }}>Loading...</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <Navbar />
       <div className="container mx-auto px-4 py-8 max-w-7xl">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="heading-xl" style={{ color: 'var(--foreground)' }}>System Prompt Editor</h1>
+          <h1 className="heading-xl" style={{ color: 'var(--color-text)' }}>System Prompt Editor</h1>
           <Button onClick={handleCreateNew}>
             <Plus size={20} style={{ marginRight: 'var(--spacing-2)' }} />
             New Prompt
@@ -205,14 +205,14 @@ export default function PromptEditorPage() {
           {/* Sidebar - Prompt List */}
           <div className="lg:col-span-1">
             <div className="card">
-              <h2 className="heading-md mb-4" style={{ color: 'var(--foreground)' }}>Saved Prompts</h2>
+              <h2 className="heading-md mb-4" style={{ color: 'var(--color-text)' }}>Saved Prompts</h2>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
                 {(prompts || []).map((prompt) => (
                   <button
                     key={prompt.id}
                     onClick={() => loadPrompt(prompt.id)}
                     className={`list-row text-left ${
-                      selectedPrompt?.id === prompt.id ? 'bg-[var(--primary)] text-[var(--primary-foreground)]' : ''
+                      selectedPrompt?.id === prompt.id ? 'bg-[var(--color-text)] text-[var(--color-bg)]' : ''
                     }`}
                     style={{
                       width: '100%',
@@ -224,7 +224,7 @@ export default function PromptEditorPage() {
                         <span className="label-sm font-medium truncate">{prompt.name}</span>
                         {prompt.isActive && (
                           <span className="badge flex-shrink-0 ml-2" style={{
-                            background: 'var(--success)',
+                            background: 'var(--color-met)',
                             color: 'white',
                             fontSize: '12px'
                           }}>
@@ -262,7 +262,7 @@ export default function PromptEditorPage() {
                           style={{ fontWeight: 600 }}
                         />
                       ) : (
-                        <h2 className="heading-lg" style={{ color: 'var(--foreground)' }}>{selectedPrompt?.name}</h2>
+                        <h2 className="heading-lg" style={{ color: 'var(--color-text)' }}>{selectedPrompt?.name}</h2>
                       )}
                     </div>
                     <div className="flex items-center gap-2 ml-4">
@@ -281,7 +281,7 @@ export default function PromptEditorPage() {
                               disabled={saving}
                               size="sm"
                               style={{
-                                background: 'var(--success)',
+                                background: 'var(--color-met)',
                                 color: 'white'
                               }}
                             >
@@ -339,7 +339,7 @@ export default function PromptEditorPage() {
                       />
                     ) : (
                       selectedPrompt?.description && (
-                        <p className="body-text" style={{ color: 'var(--muted-foreground)' }}>
+                        <p className="body-text" style={{ color: 'var(--color-text-muted)' }}>
                           {selectedPrompt.description}
                         </p>
                       )
@@ -348,7 +348,7 @@ export default function PromptEditorPage() {
 
                   {/* Content Editor */}
                   <div className="mb-4">
-                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--foreground)' }}>
+                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
                       System Prompt Content
                     </label>
                     <textarea
@@ -366,28 +366,28 @@ export default function PromptEditorPage() {
                         opacity: isEditing ? 1 : 0.7
                       }}
                     />
-                    <p className="caption mt-2" style={{ color: 'var(--muted-foreground)' }}>
+                    <p className="caption mt-2" style={{ color: 'var(--color-text-muted)' }}>
                       Characters: {content.length} | Lines: {content.split('\n').length}
                     </p>
                   </div>
 
                   {/* Metadata */}
                   {selectedPrompt && !isEditing && (
-                    <div className="mt-6 pt-6" style={{ borderTop: `0.5px solid var(--separator)` }}>
+                    <div className="mt-6 pt-6" style={{ borderTop: `0.5px solid var(--color-line)` }}>
                       <div className="grid grid-cols-2 gap-4">
                         <div>
-                          <p className="caption" style={{ color: 'var(--muted-foreground)' }}>Status</p>
-                          <p className="body-text font-medium" style={{ color: 'var(--foreground)' }}>
+                          <p className="caption" style={{ color: 'var(--color-text-muted)' }}>Status</p>
+                          <p className="body-text font-medium" style={{ color: 'var(--color-text)' }}>
                             {selectedPrompt.isActive ? (
-                              <span style={{ color: 'var(--success)' }}>Active</span>
+                              <span style={{ color: 'var(--color-met)' }}>Active</span>
                             ) : (
-                              <span style={{ color: 'var(--muted-foreground)' }}>Inactive</span>
+                              <span style={{ color: 'var(--color-text-muted)' }}>Inactive</span>
                             )}
                           </p>
                         </div>
                         <div>
-                          <p className="caption" style={{ color: 'var(--muted-foreground)' }}>Last Updated</p>
-                          <p className="body-text font-medium" style={{ color: 'var(--foreground)' }}>
+                          <p className="caption" style={{ color: 'var(--color-text-muted)' }}>Last Updated</p>
+                          <p className="body-text font-medium" style={{ color: 'var(--color-text)' }}>
                             {new Date(selectedPrompt.updatedAt).toLocaleDateString()}
                           </p>
                         </div>
@@ -397,7 +397,7 @@ export default function PromptEditorPage() {
                 </>
               ) : (
                 <div className="text-center" style={{ padding: 'var(--spacing-8) 0' }}>
-                  <p className="body-text mb-4" style={{ color: 'var(--muted-foreground)' }}>No prompt selected</p>
+                  <p className="body-text mb-4" style={{ color: 'var(--color-text-muted)' }}>No prompt selected</p>
                   <Button onClick={handleCreateNew}>
                     <Plus size={20} style={{ marginRight: 'var(--spacing-2)' }} />
                     Create Your First Prompt

--- a/src/app/api/admin/policies/[id]/route.ts
+++ b/src/app/api/admin/policies/[id]/route.ts
@@ -68,14 +68,30 @@ export async function PUT(request: NextRequest, { params }: Params) {
       );
     }
 
+    // An unparseable date reaches Prisma as `Invalid Date` and comes back a
+    // 500. The neighbouring fields are validated; this one was not.
+    let parsedEffectiveDate: Date | undefined;
+    if (effectiveDate !== undefined) {
+      parsedEffectiveDate = new Date(effectiveDate);
+      if (Number.isNaN(parsedEffectiveDate.getTime())) {
+        return validationError('effectiveDate is not a valid date', {
+          effectiveDate: ['Expected a date the runtime can parse, e.g. 2026-09-01.'],
+        });
+      }
+    }
+
     const policy = await prisma.policy.update({
       where: { id },
       data: {
         ...(title !== undefined && { title }),
         ...(content !== undefined && { content }),
-        ...(jurisdiction !== undefined && { jurisdiction }),
-        ...(category !== undefined && { category }),
-        ...(effectiveDate !== undefined && { effectiveDate: new Date(effectiveDate) }),
+        // The parsed values, not the raw body: validation that is thrown away
+        // stops being validation the moment the schema gains a transform.
+        ...(facets.data.jurisdiction !== undefined && {
+          jurisdiction: facets.data.jurisdiction,
+        }),
+        ...(facets.data.category !== undefined && { category: facets.data.category }),
+        ...(parsedEffectiveDate !== undefined && { effectiveDate: parsedEffectiveDate }),
         ...(isActive !== undefined && { isActive }),
         ...(metadata !== undefined && { metadata: JSON.stringify(metadata) })
       }

--- a/src/app/api/admin/policies/[id]/route.ts
+++ b/src/app/api/admin/policies/[id]/route.ts
@@ -4,6 +4,7 @@ import { ragSystem } from '@/lib/ai/rag';
 import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
+import { recordAudit } from '@/lib/audit';
 
 type Params = {
   params: Promise<{
@@ -79,6 +80,19 @@ export async function PUT(request: NextRequest, { params }: Params) {
         ...(metadata !== undefined && { metadata: JSON.stringify(metadata) })
       }
     });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'updated',
+      entity: 'policy',
+      entityId: id,
+      details: {
+        title: policy.title,
+        jurisdiction: policy.jurisdiction,
+        category: policy.category,
+        isActive: policy.isActive,
+        contentChanged: content !== undefined,
+      },
+    });
 
     // If content was updated, re-index. Purges the vector store as well as the
     // DB rows -- deleteMany alone left stale Chroma entries behind (SPEC-15) --
@@ -124,6 +138,12 @@ export async function DELETE(request: NextRequest, { params }: Params) {
     // Remaining chunks (if any) are removed by CASCADE.
     await prisma.policy.delete({
       where: { id }
+    });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'deleted',
+      entity: 'policy',
+      entityId: id,
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/admin/policies/[id]/route.ts
+++ b/src/app/api/admin/policies/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ragSystem } from '@/lib/ai/rag';
 import { requireRole } from '@/lib/session';
+import { policyFacetsSchema } from '@/lib/validation';
+import { validationError } from '@/lib/errors';
 
 type Params = {
   params: Promise<{
@@ -55,6 +57,15 @@ export async function PUT(request: NextRequest, { params }: Params) {
     const { id } = await params;
     const body = await request.json();
     const { title, content, jurisdiction, category, effectiveDate, isActive, metadata } = body;
+
+    // A partial update may omit either facet, but must not set a bad one.
+    const facets = policyFacetsSchema.partial().safeParse({ jurisdiction, category });
+    if (!facets.success) {
+      return validationError(
+        'Jurisdiction and category must each be one of the known values',
+        facets.error.flatten().fieldErrors
+      );
+    }
 
     const policy = await prisma.policy.update({
       where: { id },

--- a/src/app/api/admin/policies/route.ts
+++ b/src/app/api/admin/policies/route.ts
@@ -5,6 +5,7 @@ import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
 import { recordAudit } from '@/lib/audit';
+import { assertIndexablePolicyText, UploadError } from '@/lib/uploads';
 
 // GET /api/admin/policies - List all policies
 export async function GET() {
@@ -56,6 +57,8 @@ export async function POST(request: NextRequest) {
     }
 
     // Create policy
+    assertIndexablePolicyText(content);
+
     const facets = policyFacetsSchema.safeParse({ jurisdiction, category });
     if (!facets.success) {
       return validationError(
@@ -111,6 +114,9 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ policy, chunksCreated }, { status: 201 });
   } catch (error) {
+    if (error instanceof UploadError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
     console.error('Error creating policy:', error);
     return NextResponse.json(
       { error: 'Failed to create policy' },

--- a/src/app/api/admin/policies/route.ts
+++ b/src/app/api/admin/policies/route.ts
@@ -4,6 +4,7 @@ import { ragSystem } from '@/lib/ai/rag';
 import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
+import { recordAudit } from '@/lib/audit';
 
 // GET /api/admin/policies - List all policies
 export async function GET() {
@@ -77,6 +78,13 @@ export async function POST(request: NextRequest) {
         isActive: true,
         version: 1
       }
+    });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'created',
+      entity: 'policy',
+      entityId: policy.id,
+      details: { title: policy.title, jurisdiction: policy.jurisdiction, category: policy.category },
     });
 
     // Indexed through the RAG system, which applies the documented 1000-word /

--- a/src/app/api/admin/policies/route.ts
+++ b/src/app/api/admin/policies/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ragSystem } from '@/lib/ai/rag';
 import { requireRole } from '@/lib/session';
+import { policyFacetsSchema } from '@/lib/validation';
+import { validationError } from '@/lib/errors';
 
 // GET /api/admin/policies - List all policies
 export async function GET() {
@@ -53,12 +55,20 @@ export async function POST(request: NextRequest) {
     }
 
     // Create policy
+    const facets = policyFacetsSchema.safeParse({ jurisdiction, category });
+    if (!facets.success) {
+      return validationError(
+        'Jurisdiction and category must each be one of the known values',
+        facets.error.flatten().fieldErrors
+      );
+    }
+
     const policy = await prisma.policy.create({
       data: {
         title,
         content,
-        jurisdiction: jurisdiction || 'district',
-        category: category || 'other',
+        jurisdiction: facets.data.jurisdiction,
+        category: facets.data.category,
         effectiveDate: new Date(effectiveDate),
         metadata: JSON.stringify({
           keywords: keywords || [],

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -4,7 +4,7 @@ import { ragSystem } from '@/lib/ai/rag';
 import { writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { processDocument } from '@/lib/utils/documentProcessor';
+import { processDocument, countWords } from '@/lib/utils/documentProcessor';
 import { safeFetchText, UnsafeUrlError } from '@/lib/safe-fetch';
 import {
   assertAllowedExtension,
@@ -15,6 +15,8 @@ import {
   uploadErrorStatus,
 } from '@/lib/uploads';
 import { requireRole } from '@/lib/session';
+import { policyFacetsSchema } from '@/lib/validation';
+import { validationError } from '@/lib/errors';
 
 /** Formats the documentProcessor can actually parse. */
 const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
@@ -31,8 +33,17 @@ export async function POST(request: NextRequest) {
     const file = formData.get('file') as File | null;
     const url = formData.get('url') as string | null;
     const title = formData.get('title') as string;
-    const jurisdiction = (formData.get('jurisdiction') as string) || 'district';
-    const category = (formData.get('category') as string) || 'other';
+    const facets = policyFacetsSchema.safeParse({
+      jurisdiction: formData.get('jurisdiction'),
+      category: formData.get('category'),
+    });
+    if (!facets.success) {
+      return validationError(
+        'Jurisdiction and category must each be one of the known values',
+        facets.error.flatten().fieldErrors
+      );
+    }
+    const { jurisdiction, category } = facets.data;
     const effectiveDate = formData.get('effectiveDate') as string;
     const keywords = formData.get('keywords') as string;
 
@@ -98,6 +109,19 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
+    }
+
+    // An extraction that produced nothing must not become an active policy.
+    // A scanned PDF yields '' here, and the row was created active anyway --
+    // unretrievable, and (before B2) silently cancelling the coverage gap for
+    // its category, so one upload deleted a safety warning and reported
+    // success. countWords exists to make this visible and was never called. (B5)
+    if (countWords(content) === 0) {
+      return validationError('No text could be extracted from this document', {
+        file: [
+          'The document produced no readable text. If it is a scan, run it through OCR first.',
+        ],
+      });
     }
 
     // Create policy

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ragSystem } from '@/lib/ai/rag';
-import { writeFile, mkdir } from 'fs/promises';
+import { writeFile, mkdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { processDocument, countWords } from '@/lib/utils/documentProcessor';
+import { processDocument } from '@/lib/utils/documentProcessor';
 import { safeFetchText, UnsafeUrlError } from '@/lib/safe-fetch';
 import {
   assertAllowedExtension,
+  assertIndexablePolicyText,
   assertWithinSizeLimit,
   maxUploadBytes,
   safeUploadPath,
@@ -112,17 +113,13 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // An extraction that produced nothing must not become an active policy.
-    // A scanned PDF yields '' here, and the row was created active anyway --
-    // unretrievable, and (before B2) silently cancelling the coverage gap for
-    // its category, so one upload deleted a safety warning and reported
-    // success. countWords exists to make this visible and was never called. (B5)
-    if (countWords(content) === 0) {
-      return validationError('No text could be extracted from this document', {
-        file: [
-          'The document produced no readable text. If it is a scan, run it through OCR first.',
-        ],
-      });
+    // Rejecting after the write would leave the file on disk with no Policy row
+    // pointing at it -- the exact rule stated forty lines above.
+    try {
+      assertIndexablePolicyText(content);
+    } catch (error) {
+      if (filePath) await unlink(filePath).catch(() => {});
+      throw error;
     }
 
     // Create policy

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -17,6 +17,7 @@ import {
 import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
+import { recordAudit } from '@/lib/audit';
 
 /** Formats the documentProcessor can actually parse. */
 const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
@@ -143,6 +144,13 @@ export async function POST(request: NextRequest) {
         isActive: true,
         version: 1
       }
+    });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'created',
+      entity: 'policy',
+      entityId: policy.id,
+      details: { title: policy.title, jurisdiction: policy.jurisdiction, category: policy.category },
     });
 
     // Indexed through the RAG system, which applies the documented 1000-word /

--- a/src/app/api/admin/prompts/[id]/route.ts
+++ b/src/app/api/admin/prompts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireRole } from '@/lib/session';
+import { recordAudit } from '@/lib/audit';
 
 type Params = {
   params: Promise<{
@@ -50,6 +51,16 @@ export async function PUT(request: NextRequest, { params }: Params) {
     const body = await request.json();
     const { name, content, description, isActive } = body;
 
+    // Captured before the write. This row is loaded as the system prompt for
+    // every consultation, so an edit here changes the mandated-reporting advice
+    // the district gives -- and SystemPrompt carries only updatedAt, no prior
+    // content and no actor. Without the previous text the change is not
+    // reconstructable afterwards. (SEC-20)
+    const before = await prisma.systemPrompt.findUnique({
+      where: { id },
+      select: { name: true, content: true, isActive: true },
+    });
+
     // If activating this prompt, deactivate all others
     if (isActive) {
       await prisma.systemPrompt.updateMany({
@@ -66,6 +77,19 @@ export async function PUT(request: NextRequest, { params }: Params) {
         ...(description !== undefined && { description }),
         ...(isActive !== undefined && { isActive })
       }
+    });
+
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'updated',
+      entity: 'systemPrompt',
+      entityId: id,
+      details: {
+        name: prompt.name,
+        activated: isActive === true && before?.isActive !== true,
+        contentChanged: content !== undefined && content !== before?.content,
+        previousContent: before?.content,
+      },
     });
 
     return NextResponse.json({ prompt });
@@ -101,6 +125,14 @@ export async function DELETE(request: NextRequest, { params }: Params) {
 
     await prisma.systemPrompt.delete({
       where: { id }
+    });
+
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'deleted',
+      entity: 'systemPrompt',
+      entityId: id,
+      details: { name: prompt?.name, previousContent: prompt?.content },
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/admin/prompts/route.ts
+++ b/src/app/api/admin/prompts/route.ts
@@ -61,11 +61,8 @@ export async function POST(request: NextRequest) {
         name,
         content,
         description,
-        // From the session, never the body. This row governs mandated-reporting
-        // advice and `createdBy` is the only provenance it carries, so an
-        // attacker-chosen value is attacker-chosen attribution. CLAUDE.md:
-        // "No route may read a user id from a body or query string; that was a
-        // real vulnerability." This was the last such route. (SEC-21)
+        // From the session, never the body: this is the only provenance the
+        // row carries, and the row governs mandated-reporting advice. (SEC-21)
         createdBy: guard.user.id,
         isActive: false // New prompts start as inactive
       }

--- a/src/app/api/admin/prompts/route.ts
+++ b/src/app/api/admin/prompts/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
     if (!guard.ok) return guard.response;
 
     const body = await request.json();
-    const { name, content, description, createdBy } = body;
+    const { name, content, description } = body;
 
     // Validation
     if (!name || !content) {
@@ -60,7 +60,12 @@ export async function POST(request: NextRequest) {
         name,
         content,
         description,
-        createdBy,
+        // From the session, never the body. This row governs mandated-reporting
+        // advice and `createdBy` is the only provenance it carries, so an
+        // attacker-chosen value is attacker-chosen attribution. CLAUDE.md:
+        // "No route may read a user id from a body or query string; that was a
+        // real vulnerability." This was the last such route. (SEC-21)
+        createdBy: guard.user.id,
         isActive: false // New prompts start as inactive
       }
     });

--- a/src/app/api/admin/prompts/route.ts
+++ b/src/app/api/admin/prompts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { requireRole } from '@/lib/session';
+import { recordAudit } from '@/lib/audit';
 
 // GET /api/admin/prompts - List all prompts
 export async function GET() {
@@ -68,6 +69,13 @@ export async function POST(request: NextRequest) {
         createdBy: guard.user.id,
         isActive: false // New prompts start as inactive
       }
+    });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'created',
+      entity: 'systemPrompt',
+      entityId: prompt.id,
+      details: { name: prompt.name },
     });
 
     return NextResponse.json({ prompt }, { status: 201 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -91,16 +91,9 @@ export async function POST(request: NextRequest) {
       .reverse()
       .filter(c => c.sender !== SUMMARY_SENDER);
 
-    // The window is a fixed row count taken from the end, so its first entry is
-    // an assistant turn whenever an odd number of rows was dropped -- which
-    // happens as soon as the transcript holds an unpaired row. Two are created
-    // deliberately: a user message is persisted before a model call that then
-    // fails, and every summary row sits inside the take-20 window but is
-    // filtered out above. The Anthropic API rejects a leading assistant
-    // message, so the turn 503'd as "technical difficulties"; the user's
-    // message was then persisted, flipping the parity, so the next send worked
-    // and the one after failed again. Intermittent, mid-incident, and reported
-    // as nothing more specific than "it keeps erroring". (FLOW-36)
+    // The API rejects a leading assistant message. The window is a fixed row
+    // count, so it starts on one whenever an odd number of rows was dropped --
+    // which an unpaired user turn or a filtered summary row both cause. (FLOW-36)
     while (priorMessages.length > 0 && priorMessages[0].sender !== 'user') {
       priorMessages.shift();
     }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -91,6 +91,20 @@ export async function POST(request: NextRequest) {
       .reverse()
       .filter(c => c.sender !== SUMMARY_SENDER);
 
+    // The window is a fixed row count taken from the end, so its first entry is
+    // an assistant turn whenever an odd number of rows was dropped -- which
+    // happens as soon as the transcript holds an unpaired row. Two are created
+    // deliberately: a user message is persisted before a model call that then
+    // fails, and every summary row sits inside the take-20 window but is
+    // filtered out above. The Anthropic API rejects a leading assistant
+    // message, so the turn 503'd as "technical difficulties"; the user's
+    // message was then persisted, flipping the parity, so the next send worked
+    // and the one after failed again. Intermittent, mid-incident, and reported
+    // as nothing more specific than "it keeps erroring". (FLOW-36)
+    while (priorMessages.length > 0 && priorMessages[0].sender !== 'user') {
+      priorMessages.shift();
+    }
+
     // Save user message
     await prisma.conversation.create({
       data: {

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -12,6 +12,8 @@ import {
   UploadError,
 } from '@/lib/uploads';
 import { requireRole, requireUser } from '@/lib/session';
+import { policyFacetsSchema } from '@/lib/validation';
+import { validationError } from '@/lib/errors';
 
 const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
 
@@ -61,8 +63,17 @@ export async function POST(request: NextRequest) {
 
     const formData = await request.formData();
     const title = formData.get('title') as string;
-    const jurisdiction = (formData.get('jurisdiction') as string) || 'district';
-    const category = (formData.get('category') as string) || 'other';
+    const facets = policyFacetsSchema.safeParse({
+      jurisdiction: formData.get('jurisdiction'),
+      category: formData.get('category'),
+    });
+    if (!facets.success) {
+      return validationError(
+        'Jurisdiction and category must each be one of the known values',
+        facets.error.flatten().fieldErrors
+      );
+    }
+    const { jurisdiction, category } = facets.data;
     const effectiveDate = formData.get('effectiveDate') as string;
     const file = formData.get('file') as File;
 

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -14,6 +14,7 @@ import {
 import { requireRole, requireUser } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
+import { recordAudit } from '@/lib/audit';
 
 const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
 
@@ -119,6 +120,13 @@ export async function POST(request: NextRequest) {
         effectiveDate: effectiveDate ? new Date(effectiveDate) : new Date(),
         isActive: true,
       },
+    });
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'created',
+      entity: 'policy',
+      entityId: policy.id,
+      details: { title: policy.title, jurisdiction: policy.jurisdiction, category: policy.category },
     });
 
     // Add to RAG system for search with metadata

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -10,6 +10,7 @@ import {
   assertWithinSizeLimit,
   safeUploadPath,
   UploadError,
+  assertIndexablePolicyText,
 } from '@/lib/uploads';
 import { requireRole, requireUser } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
@@ -108,6 +109,8 @@ export async function POST(request: NextRequest) {
       const processed = await processDocument(uploadPath);
       content = processed.content;
     }
+
+    assertIndexablePolicyText(content);
 
     // Create policy record
     const policy = await prisma.policy.create({

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -555,6 +555,7 @@ export default function ChatPage() {
                               ) : (
                                 <CoverageGapCard
                                   categories={message.coverage.categoriesWithoutLocalPolicy}
+                                  byCategory={message.coverage.byCategory}
                                 />
                               ))}
                           </div>

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -262,15 +262,15 @@ export default function ChatPage() {
   };
 
   return (
-    <div className="min-h-screen" style={{ background: 'var(--background)' }}>
+    <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <Navbar />
       <div className="flex" style={{ height: 'calc(100vh - 52px)' }}>
         {/* Sidebar */}
         <div
           style={{
             width: sidebarOpen ? '260px' : '0px',
-            borderRight: '1px solid var(--separator)',
-            background: 'var(--background)',
+            borderRight: '1px solid var(--color-line)',
+            background: 'var(--color-bg)',
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
@@ -285,18 +285,18 @@ export default function ChatPage() {
                 width: '100%',
                 padding: '10px 14px',
                 background: 'transparent',
-                border: '1px solid var(--border)',
+                border: '1px solid var(--color-line)',
                 borderRadius: '8px',
                 display: 'flex',
                 alignItems: 'center',
                 gap: '8px',
                 cursor: 'pointer',
-                color: 'var(--foreground)',
+                color: 'var(--color-text)',
                 fontSize: '14px',
                 fontWeight: 500,
                 transition: 'background 0.2s'
               }}
-              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--secondary)'}
+              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-input)'}
               onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
             >
               <Plus size={18} />
@@ -314,11 +314,11 @@ export default function ChatPage() {
             flexDirection: 'column'
           }}>
             {loadingHistories ? (
-              <div style={{ padding: '10px 12px', color: 'var(--muted-foreground)', fontSize: '14px' }}>
+              <div style={{ padding: '10px 12px', color: 'var(--color-text-muted)', fontSize: '14px' }}>
                 Loading...
               </div>
             ) : previousChats.length === 0 ? (
-              <div style={{ padding: '10px 12px', color: 'var(--muted-foreground)', fontSize: '14px' }}>
+              <div style={{ padding: '10px 12px', color: 'var(--color-text-muted)', fontSize: '14px' }}>
                 No previous chats
               </div>
             ) : (
@@ -332,9 +332,9 @@ export default function ChatPage() {
                     borderRadius: '8px',
                     cursor: 'pointer',
                     transition: 'background 0.2s',
-                    background: incidentId === chat.id ? 'var(--secondary)' : 'transparent'
+                    background: incidentId === chat.id ? 'var(--color-input)' : 'transparent'
                   }}
-                  onMouseEnter={(e) => e.currentTarget.style.background = 'var(--secondary)'}
+                  onMouseEnter={(e) => e.currentTarget.style.background = 'var(--color-input)'}
                   onMouseLeave={(e) => {
                     if (incidentId !== chat.id) {
                       e.currentTarget.style.background = 'transparent';
@@ -343,7 +343,7 @@ export default function ChatPage() {
                 >
                   <div style={{
                     fontSize: '14px',
-                    color: 'var(--foreground)',
+                    color: 'var(--color-text)',
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
@@ -371,7 +371,7 @@ export default function ChatPage() {
             justifyContent: 'space-between',
             padding: '0 16px',
             minHeight: '48px',
-            borderBottom: '1px solid var(--separator)',
+            borderBottom: '1px solid var(--color-line)',
             flexShrink: 0
           }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
@@ -381,18 +381,18 @@ export default function ChatPage() {
                   style={{
                     padding: '6px',
                     borderRadius: '6px',
-                    color: 'var(--muted-foreground)',
+                    color: 'var(--color-text-muted)',
                     background: 'transparent',
                     border: 'none',
                     cursor: 'pointer',
                     transition: 'all 0.2s'
                   }}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.color = 'var(--foreground)';
-                    e.currentTarget.style.background = 'var(--secondary)';
+                    e.currentTarget.style.color = 'var(--color-text)';
+                    e.currentTarget.style.background = 'var(--color-input)';
                   }}
                   onMouseLeave={(e) => {
-                    e.currentTarget.style.color = 'var(--muted-foreground)';
+                    e.currentTarget.style.color = 'var(--color-text-muted)';
                     e.currentTarget.style.background = 'transparent';
                   }}
                 >
@@ -435,7 +435,7 @@ export default function ChatPage() {
                   borderRadius: '50%',
                   overflow: 'hidden',
                   marginBottom: '24px',
-                  border: '2px solid var(--primary)',
+                  border: '2px solid var(--color-text)',
                 }}>
                   <Image
                     src="/General.jpeg"
@@ -448,14 +448,14 @@ export default function ChatPage() {
                 <h2 style={{
                   fontSize: '24px',
                   fontWeight: 600,
-                  color: 'var(--foreground)',
+                  color: 'var(--color-text)',
                   marginBottom: '12px'
                 }}>
                   Chat with the General
                 </h2>
                 <p style={{
                   fontSize: '15px',
-                  color: 'var(--muted-foreground)',
+                  color: 'var(--color-text-muted)',
                   maxWidth: '420px',
                   lineHeight: '1.5'
                 }}>
@@ -482,7 +482,7 @@ export default function ChatPage() {
                           borderRadius: '50%',
                           overflow: 'hidden',
                           flexShrink: 0,
-                          border: '1px solid var(--primary)',
+                          border: '1px solid var(--color-text)',
                         }}>
                           <Image
                             src="/General.jpeg"
@@ -499,11 +499,11 @@ export default function ChatPage() {
                       }}>
                         <div style={{
                           padding: message.type === 'user' ? '12px 16px' : '0',
-                          background: message.type === 'user' ? 'var(--secondary)' : 'transparent',
+                          background: message.type === 'user' ? 'var(--color-input)' : 'transparent',
                           borderRadius: message.type === 'user' ? '16px' : '0',
                           fontSize: '15px',
                           lineHeight: '1.6',
-                          color: 'var(--foreground)',
+                          color: 'var(--color-text)',
                           whiteSpace: message.type === 'user' ? 'pre-wrap' : 'normal',
                           wordBreak: 'break-word'
                         }}>
@@ -572,7 +572,7 @@ export default function ChatPage() {
                         borderRadius: '50%',
                         overflow: 'hidden',
                         flexShrink: 0,
-                        border: '1px solid var(--primary)',
+                        border: '1px solid var(--color-text)',
                       }}>
                         <Image
                           src="/General.jpeg"
@@ -587,14 +587,14 @@ export default function ChatPage() {
                           width: '8px',
                           height: '8px',
                           borderRadius: '50%',
-                          background: 'var(--muted-foreground)',
+                          background: 'var(--color-text-muted)',
                           animation: 'bounce 1.4s infinite ease-in-out both'
                         }}></div>
                         <div style={{
                           width: '8px',
                           height: '8px',
                           borderRadius: '50%',
-                          background: 'var(--muted-foreground)',
+                          background: 'var(--color-text-muted)',
                           animation: 'bounce 1.4s infinite ease-in-out both',
                           animationDelay: '0.16s'
                         }}></div>
@@ -602,7 +602,7 @@ export default function ChatPage() {
                           width: '8px',
                           height: '8px',
                           borderRadius: '50%',
-                          background: 'var(--muted-foreground)',
+                          background: 'var(--color-text-muted)',
                           animation: 'bounce 1.4s infinite ease-in-out both',
                           animationDelay: '0.32s'
                         }}></div>
@@ -619,16 +619,16 @@ export default function ChatPage() {
           {/* Input Area */}
           <div style={{
             padding: '16px',
-            borderTop: '1px solid var(--separator)',
-            background: 'var(--background)',
+            borderTop: '1px solid var(--color-line)',
+            background: 'var(--color-bg)',
             flexShrink: 0
           }}>
             <div style={{ maxWidth: '48rem', margin: '0 auto' }}>
               <div style={{
-                border: '1px solid var(--border)',
+                border: '1px solid var(--color-line)',
                 borderRadius: '12px',
                 padding: '8px 12px',
-                background: 'var(--background)',
+                background: 'var(--color-bg)',
                 display: 'flex',
                 alignItems: 'flex-end',
                 gap: '8px'
@@ -637,7 +637,7 @@ export default function ChatPage() {
                   style={{
                     padding: '6px',
                     borderRadius: '6px',
-                    color: 'var(--muted-foreground)',
+                    color: 'var(--color-text-muted)',
                     background: 'transparent',
                     border: 'none',
                     cursor: 'pointer',
@@ -646,11 +646,11 @@ export default function ChatPage() {
                     alignItems: 'center'
                   }}
                   onMouseEnter={(e) => {
-                    e.currentTarget.style.color = 'var(--foreground)';
-                    e.currentTarget.style.background = 'var(--secondary)';
+                    e.currentTarget.style.color = 'var(--color-text)';
+                    e.currentTarget.style.background = 'var(--color-input)';
                   }}
                   onMouseLeave={(e) => {
-                    e.currentTarget.style.color = 'var(--muted-foreground)';
+                    e.currentTarget.style.color = 'var(--color-text-muted)';
                     e.currentTarget.style.background = 'transparent';
                   }}
                 >
@@ -672,7 +672,7 @@ export default function ChatPage() {
                     border: 'none',
                     outline: 'none',
                     background: 'transparent',
-                    color: 'var(--foreground)',
+                    color: 'var(--color-text)',
                     fontSize: '15px',
                     lineHeight: '1.5',
                     fontFamily: 'inherit',
@@ -695,8 +695,8 @@ export default function ChatPage() {
                   style={{
                     padding: '6px',
                     borderRadius: '6px',
-                    background: inputValue.trim() ? 'var(--primary)' : 'transparent',
-                    color: inputValue.trim() ? 'white' : 'var(--muted-foreground)',
+                    background: inputValue.trim() ? 'var(--color-text)' : 'transparent',
+                    color: inputValue.trim() ? 'white' : 'var(--color-text-muted)',
                     border: 'none',
                     cursor: inputValue.trim() ? 'pointer' : 'not-allowed',
                     transition: 'all 0.2s',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,7 +131,7 @@ export default function HomePage() {
         {!loading && !error && open.length === 0 && (
           <StateBlock
             title="Nothing outstanding"
-            body="Obligations appear here as soon as an incident is classified, with the deadline the policy sets."
+            body="Obligations appear here as soon as an incident is classified. Check each deadline against the cited policy before you rely on it."
           />
         )}
 

--- a/src/app/policies/page.tsx
+++ b/src/app/policies/page.tsx
@@ -102,8 +102,9 @@ export default function PoliciesPage() {
                 ? 'No district or school policies are loaded.'
                 : `Only ${localCount} district or school ${localCount === 1 ? 'policy is' : 'policies are'} loaded.`}
             </span>{' '}
-            Guidance will lean on state and federal law until more are added. Deadlines are still
-            correct, but there will be more coverage gaps than there should be.
+            Guidance will lean on state and federal law until more are added, and there will be
+            more coverage gaps than there should be. Deadlines shown on obligations are not yet
+            derived from the cited policy — confirm each one before acting on it.
           </div>
         )}
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -122,7 +122,7 @@ export default function Navbar() {
           aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={isMobileMenuOpen}
           onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          className="flex min-h-[44px] min-w-[44px] items-center justify-center border-none bg-transparent p-2 text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] md:hidden"
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center border-none bg-transparent p-2 text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text)] md:hidden"
         >
           {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -131,7 +131,7 @@ export default function Navbar() {
       {/* Mobile Menu */}
       {isMobileMenuOpen && (
         <div style={{
-          borderTop: '0.5px solid var(--separator)',
+          borderTop: '0.5px solid var(--color-line)',
           padding: '8px'
         }}>
           <div className="flex flex-col gap-1">

--- a/src/components/design/CoverageGapCard.tsx
+++ b/src/components/design/CoverageGapCard.tsx
@@ -3,19 +3,39 @@ import { CATEGORY_LABELS } from '@/types';
 /**
  * A category the incident implicates that no district or school policy covers.
  *
- * Deliberately amber and not red: this is attention, not alarm. The guidance
- * above it is still sound -- it rests on the statute directly -- and the point
- * is to stop the administrator following a local procedure that does not
- * exist, and to tell the district it has a hole. (design 1c/1j)
+ * Deliberately amber and not red: this is attention, not alarm. The point is to
+ * stop the administrator following a local procedure that does not exist, and
+ * to tell the district it has a hole. (design 1c/1j)
+ *
+ * Two different gaps, and the difference matters. If federal or state authority
+ * was retrieved, the guidance does rest on something and only the local
+ * procedure is missing. If the library holds nothing at any level, the guidance
+ * rests on nothing the system can show -- and this card used to vouch for it
+ * anyway, printing "It is sound" beneath a deadline no retrieved policy
+ * supported. `byCategory` carries the distinction; it was computed and never
+ * read. (FLOW-34)
  */
-export function CoverageGapCard({ categories }: { categories: string[] }) {
+export function CoverageGapCard({
+  categories,
+  byCategory,
+}: {
+  categories: string[];
+  byCategory?: Record<string, string[]>;
+}) {
   if (categories.length === 0) return null;
 
-  const named = categories.map(c => CATEGORY_LABELS[c] ?? c);
-  const list =
-    named.length === 1
+  const phrase = (cs: string[]) => {
+    const named = cs.map(c => CATEGORY_LABELS[c] ?? c);
+    return named.length === 1
       ? named[0].toLowerCase()
       : `${named.slice(0, -1).join(', ').toLowerCase()} and ${named[named.length - 1].toLowerCase()}`;
+  };
+
+  const unsupported = byCategory
+    ? categories.filter(c => (byCategory[c] ?? []).length === 0)
+    : [];
+  const localOnly = categories.filter(c => !unsupported.includes(c));
+  const list = phrase(categories);
 
   return (
     <div className="flex gap-[14px] rounded-[16px] border border-attention/40 bg-attention/[0.07] px-5 py-[18px]">
@@ -37,11 +57,20 @@ export function CoverageGapCard({ categories }: { categories: string[] }) {
         <span className="text-[15px] font-medium leading-[1.3] text-text">
           No district or school policy covers {list}
         </span>
-        <span className="text-[14px] leading-[1.6] text-text-secondary">
-          The guidance above uses the state and federal requirements directly. It is sound, but
-          there is no local procedure to follow for this part — document your reasoning in the
-          incident file.
-        </span>
+        {localOnly.length > 0 && (
+          <span className="text-[14px] leading-[1.6] text-text-secondary">
+            For {phrase(localOnly)}, the guidance above uses the state and federal requirements
+            directly. There is no local procedure to follow for this part — document your
+            reasoning in the incident file.
+          </span>
+        )}
+        {unsupported.length > 0 && (
+          <span className="text-[14px] leading-[1.6] text-text-secondary">
+            For {phrase(unsupported)}, the library holds no policy at any level — federal, state,
+            district or school. Nothing above rests on a retrieved policy for this part. Confirm
+            the obligation with your compliance officer before acting on it.
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,17 +9,17 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "btn-primary",
-        destructive: "btn-primary bg-[var(--destructive)] hover:bg-[#ff5a50] active:bg-[#ff3b30]",
+        destructive: "btn-primary bg-[var(--color-overdue)] hover:bg-[#ff5a50] active:bg-[#ff3b30]",
         outline: "btn-secondary",
         secondary: "btn-secondary",
         ghost: "btn-ghost",
-        link: "text-[var(--primary)] underline-offset-4 hover:underline min-h-[var(--touch-target)] px-5",
+        link: "text-[var(--color-text)] underline-offset-4 hover:underline min-h-[44px] px-5",
       },
       size: {
-        default: "min-h-[var(--touch-target)] px-6",
+        default: "min-h-[44px] px-6",
         sm: "min-h-[36px] px-4 text-[15px]",
         lg: "min-h-[52px] px-8 text-[17px]",
-        icon: "h-[var(--touch-target)] w-[var(--touch-target)] p-0",
+        icon: "h-[44px] w-[44px] p-0",
       },
     },
     defaultVariants: {

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -79,11 +79,9 @@ export interface ClaudeResponse {
 /**
  * The instruction that stands in for policy the system could not find.
  *
- * Shared rather than inlined because it was inlined once, in the guidance path
- * only, and the summary path -- whose output is persisted to the incident file
- * -- went without it while still naming "JICK, ACAC, JLF" as examples for the
- * model to reach for. A guard protecting one of two callers is the shape of
- * that bug, so both now read from here. (B4)
+ * Shared because both callers need it: with nothing retrieved, the "JICK,
+ * ACAC, JLF" examples in each prompt are the only codes the model has to
+ * reach for. (B4)
  */
 const NO_POLICY_RETRIEVED_GUARD = `IMPORTANT - NO POLICY RETRIEVED FOR THIS QUERY:
 No district policy text was retrieved for this question. For this response you must:
@@ -97,11 +95,8 @@ No district policy text was retrieved for this question. For this response you m
 /**
  * What to say when the library has no local policy for an implicated area.
  *
- * Distinguishes "federal or state authority exists above it" from "nothing at
- * any level". Both the prompt and the coverage card used to assert the guidance
- * rested soundly on federal or state text without checking that any had been
- * retrieved -- so with an empty library they vouched for a deadline nothing in
- * the system supported. (FLOW-34)
+ * "No local policy" and "nothing at any level" need different wording: the
+ * second cannot claim the guidance rests on federal or state text. (FLOW-34)
  */
 function buildCoverageNote(coverage?: PolicyCoverage): string {
   const gaps = coverage?.categoriesWithoutLocalPolicy ?? [];

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -76,6 +76,55 @@ export interface ClaudeResponse {
   stopReason: string;
 }
 
+/**
+ * The instruction that stands in for policy the system could not find.
+ *
+ * Shared rather than inlined because it was inlined once, in the guidance path
+ * only, and the summary path -- whose output is persisted to the incident file
+ * -- went without it while still naming "JICK, ACAC, JLF" as examples for the
+ * model to reach for. A guard protecting one of two callers is the shape of
+ * that bug, so both now read from here. (B4)
+ */
+const NO_POLICY_RETRIEVED_GUARD = `IMPORTANT - NO POLICY RETRIEVED FOR THIS QUERY:
+No district policy text was retrieved for this question. For this response you must:
+- NOT cite or invent any policy code (JICK, ACAC, JLF or otherwise)
+- NOT state district-specific deadlines or requirements as established fact
+- Say plainly that you could not locate the applicable district policy
+- Limit yourself to general best practice and statutory obligations you are
+  confident about, labelled as such
+- Recommend they confirm with their compliance officer or legal counsel`;
+
+/**
+ * What to say when the library has no local policy for an implicated area.
+ *
+ * Distinguishes "federal or state authority exists above it" from "nothing at
+ * any level". Both the prompt and the coverage card used to assert the guidance
+ * rested soundly on federal or state text without checking that any had been
+ * retrieved -- so with an empty library they vouched for a deadline nothing in
+ * the system supported. (FLOW-34)
+ */
+function buildCoverageNote(coverage?: PolicyCoverage): string {
+  const gaps = coverage?.categoriesWithoutLocalPolicy ?? [];
+  if (gaps.length === 0) return '';
+
+  const byCategory = coverage?.byCategory ?? {};
+  const nothingAnywhere = gaps.filter(c => (byCategory[c] ?? []).length === 0);
+  const localOnly = gaps.filter(c => (byCategory[c] ?? []).length > 0);
+
+  let note = '\n\nPOLICY COVERAGE GAP:';
+  if (localOnly.length > 0) {
+    note += `
+This incident implicates the following areas, and the policy library holds NO district or school policy for them: ${localOnly.join(', ')}.
+State whatever federal or state requirements you can support from the text above, then tell them plainly that you could not find a district or school policy covering this and that they should confirm the local procedure with their compliance officer. Do not present a federal or state requirement as if it were district procedure, and do not invent a local policy code.`;
+  }
+  if (nothingAnywhere.length > 0) {
+    note += `
+The library holds NO policy at ANY level -- federal, state, district or school -- for: ${nothingAnywhere.join(', ')}.
+For these areas do not state a deadline, a requirement or a citation as established fact. Say plainly that the library holds nothing covering them and that they must confirm the obligation with their compliance officer or legal counsel.`;
+  }
+  return note;
+}
+
 class ClaudeService {
   private client: Anthropic | null = null;
   private model: string;
@@ -282,14 +331,7 @@ Remember: You're here to help them navigate this successfully. Be their trusted 
     // its absence is a compliance gap the administrator should hear about --
     // not something to paper over by citing the statute as if it were the
     // district's own procedure.
-    const gaps = coverage?.categoriesWithoutLocalPolicy ?? [];
-    const coverageNote = gaps.length > 0
-      ? `
-
-POLICY COVERAGE GAP:
-This incident implicates the following areas, and the policy library holds NO district or school policy for them: ${gaps.join(', ')}.
-State whatever federal or state requirements you can support from the text above, then tell them plainly that you could not find a district or school policy covering this and that they should confirm the local procedure with their compliance officer. Do not present a federal or state requirement as if it were district procedure, and do not invent a local policy code.`
-      : '';
+    const coverageNote = buildCoverageNote(coverage);
 
     const finalSystemPrompt = hasPolicyContext
       ? `${systemPromptContent}
@@ -307,14 +349,7 @@ ${policyContext}${coverageNote}`
 Available Policy Context:
 (none)
 
-IMPORTANT - NO POLICY RETRIEVED FOR THIS QUERY:
-No district policy text was retrieved for this question. For this response you must:
-- NOT cite or invent any policy code (JICK, ACAC, JLF or otherwise)
-- NOT state district-specific deadlines or requirements as established fact
-- Say plainly that you could not locate the applicable district policy
-- Limit yourself to general best practice and statutory obligations you are
-  confident about, labelled as such
-- Recommend they confirm with their compliance officer or legal counsel`;
+${NO_POLICY_RETRIEVED_GUARD}`;
 
     const messages: ClaudeMessage[] = [
       ...conversationHistory,
@@ -460,8 +495,13 @@ Example: ["Question 1?", "Question 2?", "Question 3?"]`;
    */
   async generateChatSummary(
     conversationHistory: ClaudeMessage[],
-    policyContext: string
+    policyContext: string,
+    coverage?: PolicyCoverage
   ): Promise<ClaudeResponse> {
+    // The summary is persisted and rendered in the incident timeline, so it is
+    // the artefact most likely to be printed and filed. It therefore gets the
+    // same retrieval guard the guidance path has, not a weaker one. (B4)
+    const hasPolicyContext = policyContext.trim().length > 0;
     const systemPrompt = `You are a school district attorney reviewing an incident consultation session. Generate a comprehensive summary report for the administrator's records.
 
 Your summary MUST include these sections:
@@ -472,7 +512,7 @@ Your summary MUST include these sections:
 - Incident classification and severity assessment
 
 ## POLICY ANALYSIS
-- List each policy referenced during the consultation with specific codes (e.g., "JICK", "ACAC", "JLF")
+- List each policy referenced during the consultation, citing it exactly as it appears in the excerpts below
 - For each policy, explain how it applies to this incident
 - Cite specific sections or requirements from the policies
 - Identify any policy gaps or areas where guidance was limited
@@ -504,7 +544,7 @@ Your summary MUST include these sections:
 - Suggest any additional risk mitigation steps
 - Provide guidance on documentation and evidence preservation
 
-Format the summary professionally, as it may become part of the incident file. Be specific, cite policies by code, and use exact timelines when mentioned in the conversation.`;
+Format the summary professionally, as it may become part of the incident file. Be specific, cite only policies that appear in the excerpts below, and use exact timelines only where the conversation or an excerpt states them.`;
 
     const conversationText = conversationHistory
       .map(msg => `${msg.role === 'user' ? 'Administrator' : 'Counsel'}: ${msg.content}`)
@@ -516,13 +556,22 @@ CONVERSATION TRANSCRIPT:
 ${conversationText}
 
 POLICIES REFERENCED DURING CONSULTATION:
-${policyContext}
+${hasPolicyContext ? policyContext : '(none retrieved)'}
 
 Generate the summary following the required format above.`;
 
+    const finalSystemPrompt = hasPolicyContext
+      ? `${systemPrompt}${buildCoverageNote(coverage)}`
+      : `${systemPrompt}
+
+${NO_POLICY_RETRIEVED_GUARD}
+
+This applies to the POLICY ANALYSIS section too: leave it empty rather than
+naming a policy, and say that none could be retrieved for this incident.${buildCoverageNote(coverage)}`;
+
     const response = await this.generateResponse(
       [{ role: 'user', content: summaryRequest }],
-      systemPrompt,
+      finalSystemPrompt,
       { temperature: 0.3, maxTokens: 2048 }
     );
 

--- a/src/lib/ai/incident-summary.ts
+++ b/src/lib/ai/incident-summary.ts
@@ -54,7 +54,10 @@ export async function generateIncidentSummary(
 
   // Retrieve with the incident's own classification, so the summary rests on
   // the same policies the guidance did rather than a different set.
-  const { response: policyContext } = await ragSystem.generateResponseWithCitations(
+  // Coverage travels with the context: the summary is the one artefact that
+  // goes into the file, and it was the only output that never said a local
+  // policy was missing. (SPEC-41)
+  const { response: policyContext, coverage } = await ragSystem.generateResponseWithCitations(
     `${incident.title} ${incident.description ?? ''}`,
     {
       incidentId: incident.id,
@@ -63,7 +66,11 @@ export async function generateIncidentSummary(
     }
   );
 
-  const summary = await claudeService.generateChatSummary(conversationHistory, policyContext);
+  const summary = await claudeService.generateChatSummary(
+    conversationHistory,
+    policyContext,
+    coverage
+  );
 
   const message = await prisma.conversation.create({
     data: {

--- a/src/lib/ai/rag.ts
+++ b/src/lib/ai/rag.ts
@@ -497,13 +497,9 @@ export class RAGSystem {
     }
 
     const policies = await prisma.policy.findMany({
-      // A policy only counts as coverage if retrieval can actually return it.
-      // A row with chunks deleted -- which production has reached, when a
-      // re-index deleted them and failed to write replacements -- is invisible
-      // to search, so counting it would suppress the very gap warning that
-      // says the library is empty. `policy-coverage.ts` states this rule for
-      // the offline report; the live path that decides what the administrator
-      // is told must not be more permissive than it. (B2)
+      // Coverage means retrievable. A row with no chunks is invisible to
+      // search, so counting it suppresses the gap warning that says the
+      // library is empty -- the rule policy-coverage.ts already states. (B2)
       where: { isActive: true, category: { in: categories }, chunks: { some: {} } },
       select: { category: true, jurisdiction: true },
       distinct: ['category', 'jurisdiction'],

--- a/src/lib/ai/rag.ts
+++ b/src/lib/ai/rag.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/db';
 import {
   categoriesForIncidentType,
+  guaranteedCategoriesFor,
   JURISDICTION_LABELS,
   POLICY_JURISDICTIONS,
   PolicyChunk,
@@ -317,17 +318,21 @@ export class RAGSystem {
     // reporting always. Retrieve more than the display limit so several
     // jurisdictions have a chance to appear rather than one verbose policy
     // crowding out the others.
+    // The filter may be empty (unclassified, or `other`); the guaranteed set
+    // never is. Search stays unconstrained in that case, but representation and
+    // coverage still run -- see guaranteedCategoriesFor. (B3)
     const categories = categoriesForIncidentType(context?.incidentType);
+    const guaranteed = guaranteedCategoriesFor(context?.incidentType);
     const matched = await this.searchRelevantPolicies(retrievalQuery, 12, {
       categories,
       isActive: true,
     });
 
-    const relevantChunks = await this.ensureCategoryRepresentation(matched, categories);
+    const relevantChunks = await this.ensureCategoryRepresentation(matched, guaranteed);
 
     const policyContext = this.buildJurisdictionContext(relevantChunks);
     const citations = this.buildCitations(relevantChunks);
-    const coverage = await this.assessCoverage(categories);
+    const coverage = await this.assessCoverage(guaranteed);
 
     return {
       response: policyContext,
@@ -492,7 +497,14 @@ export class RAGSystem {
     }
 
     const policies = await prisma.policy.findMany({
-      where: { isActive: true, category: { in: categories } },
+      // A policy only counts as coverage if retrieval can actually return it.
+      // A row with chunks deleted -- which production has reached, when a
+      // re-index deleted them and failed to write replacements -- is invisible
+      // to search, so counting it would suppress the very gap warning that
+      // says the library is empty. `policy-coverage.ts` states this rule for
+      // the offline report; the live path that decides what the administrator
+      // is told must not be more permissive than it. (B2)
+      where: { isActive: true, category: { in: categories }, chunks: { some: {} } },
       select: { category: true, jurisdiction: true },
       distinct: ['category', 'jurisdiction'],
     });

--- a/src/lib/deadline.test.ts
+++ b/src/lib/deadline.test.ts
@@ -69,3 +69,34 @@ describe('describeDeadline', () => {
     expect(fromString.label).toBe(fromDate.label);
   });
 });
+
+describe('interval carry', () => {
+  const MINUTE = 60_000;
+
+  // Rounding each unit independently let Math.round return 60, so the last
+  // thirty seconds of every hour rendered a time that does not exist -- on the
+  // app's most prominent element, in tabular mono precisely so it reads
+  // cleanly. Every existing case in this file sits comfortably inside its
+  // unit, so none of them crossed a carry. (TEST-36)
+  it('carries 60 minutes into an hour rather than rendering 60m', () => {
+    expect(describeDeadline(at(59.5 * MINUTE), 'pending', null, NOW).label).toBe('in 1h');
+    expect(describeDeadline(at(59 * MINUTE + 31_000), 'pending', null, NOW).label).toBe('in 1h');
+  });
+
+  it('carries 60 minutes into a day rather than rendering 23h 60m', () => {
+    expect(
+      describeDeadline(at(23 * HOUR + 59.5 * MINUTE), 'pending', null, NOW).label
+    ).toBe('in 1d');
+  });
+
+  it('still reports the minute below the carry', () => {
+    expect(describeDeadline(at(59 * MINUTE), 'pending', null, NOW).label).toBe('in 59m');
+    expect(describeDeadline(at(23 * HOUR + 59 * MINUTE), 'pending', null, NOW).label).toBe(
+      'in 23h 59m'
+    );
+  });
+
+  it('never renders zero minutes for an interval that has not elapsed', () => {
+    expect(describeDeadline(at(20_000), 'pending', null, NOW).label).toBe('in 1m');
+  });
+});

--- a/src/lib/deadline.ts
+++ b/src/lib/deadline.ts
@@ -50,12 +50,19 @@ function formatAbsolute(due: Date, now: Date): string {
 
 function formatInterval(ms: number): string {
   const abs = Math.abs(ms);
-  if (abs < HOUR) return `${Math.max(1, Math.round(abs / MINUTE))}m`;
-  if (abs < DAY) {
-    const hours = Math.floor(abs / HOUR);
-    const minutes = Math.round((abs % HOUR) / MINUTE);
+
+  // Round to whole minutes once, then carry. Rounding each unit independently
+  // let Math.round return 60: 59m30s rendered "in 60m" and 23h59m30s rendered
+  // "in 23h 60m". On a countdown in tabular mono, the last thirty seconds of
+  // every hour displayed a time that does not exist. (TEST-36)
+  const totalMinutes = Math.round(abs / MINUTE);
+  if (totalMinutes < 60) return `${Math.max(1, totalMinutes)}m`;
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const minutes = totalMinutes % 60;
     // Minute precision only inside the day, where it changes what you do next.
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+    return minutes > 0 ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
   }
   return `${Math.round(abs / DAY)}d`;
 }

--- a/src/lib/uploads.test.ts
+++ b/src/lib/uploads.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { resolve, sep } from 'path';
 import {
   assertAllowedExtension,
+  assertIndexablePolicyText,
   assertWithinSizeLimit,
   DEFAULT_MAX_UPLOAD_BYTES,
   fileExtension,
@@ -107,6 +108,39 @@ describe('assertWithinSizeLimit', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(UploadError);
       expect((e as UploadError).status).toBe(413);
+    }
+  });
+});
+
+describe('assertIndexablePolicyText', () => {
+  // Retrieval works from chunks and chunks come from this text, so a policy
+  // with none is invisible to search while still counting as loaded. There are
+  // three ingestion routes; this is the rule all three call. (B5)
+
+  it('accepts text that will produce chunks', () => {
+    expect(() => assertIndexablePolicyText('Staff must report within 24 hours.')).not.toThrow();
+  });
+
+  it('rejects an extraction that produced nothing', () => {
+    // What a scanned PDF yields.
+    expect(() => assertIndexablePolicyText('')).toThrow(/No text could be extracted/);
+  });
+
+  it('rejects whitespace, which a truthiness check would let through', () => {
+    // The JSON route guards with `!content`, which passes for all of these.
+    for (const blank of ['   ', '\n\n', '\t', ' \n \t ']) {
+      expect(() => assertIndexablePolicyText(blank)).toThrow(/No text could be extracted/);
+    }
+  });
+
+  it('reports 422, not 500', () => {
+    // The document is readable and the request well-formed; the content is the
+    // problem, so this is the caller's to fix.
+    try {
+      assertIndexablePolicyText('');
+      throw new Error('expected a throw');
+    } catch (error) {
+      expect((error as { status?: number }).status).toBe(422);
     }
   });
 });

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { extname, join, resolve, sep } from 'path';
+import { countWords } from './utils/documentProcessor';
 
 /**
  * Shared upload safety helpers.
@@ -83,6 +84,26 @@ export function safeUploadPath(uploadsDir: string, ext: string): string {
 }
 
 /** Maps an UploadError to its status; anything else is a 500. */
+/**
+ * A policy whose text could not be read must not become an active policy.
+ *
+ * Retrieval works from chunks, and chunks come from this text. A row with none
+ * is invisible to search while still counting as a loaded policy to anyone
+ * reading the library -- and it takes a scanned PDF, not a malformed one, to
+ * get here.
+ *
+ * Lives here, with the other upload rules, because there are three ingestion
+ * routes and a guard on one of them is not a guard.
+ */
+export function assertIndexablePolicyText(content: string): void {
+  if (countWords(content) === 0) {
+    throw new UploadError(
+      'No text could be extracted from this document. If it is a scan, run it through OCR first.',
+      422
+    );
+  }
+}
+
 export function uploadErrorStatus(error: unknown): number {
   return error instanceof UploadError ? error.status : 500;
 }

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  policyFacetsSchema,
   chatMessageSchema,
   createIncidentSchema,
   paginationSchema,
@@ -100,5 +101,46 @@ describe('incident schemas', () => {
   it('does not accept a caller-supplied reporterId', () => {
     const r = createIncidentSchema.parse({ title: 't', description: 'd', reporterId: 'x' });
     expect(r).not.toHaveProperty('reporterId');
+  });
+});
+
+describe('policyFacetsSchema', () => {
+  // Every policy write path used to take these from the request and default the
+  // misses. A category retrieval does not match makes the policy unfindable AND
+  // -- since assessCoverage queries the same field -- makes the system report a
+  // coverage gap for an area the district has in fact loaded. (B5)
+
+  it('accepts the known facets', () => {
+    expect(
+      policyFacetsSchema.safeParse({ jurisdiction: 'district', category: 'bullying' }).success
+    ).toBe(true);
+  });
+
+  it('rejects a mis-cased jurisdiction rather than storing it', () => {
+    // 'District' is not 'district'. buildJurisdictionContext groups only over
+    // the known four, so this text is dropped from the model's context while
+    // buildCitations still lists it as a source.
+    expect(
+      policyFacetsSchema.safeParse({ jurisdiction: 'District', category: 'bullying' }).success
+    ).toBe(false);
+  });
+
+  it('rejects a mistyped category rather than defaulting it to `other`', () => {
+    const result = policyFacetsSchema.safeParse({
+      jurisdiction: 'district',
+      category: 'bullyng',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing facet rather than guessing one', () => {
+    expect(policyFacetsSchema.safeParse({ jurisdiction: 'district' }).success).toBe(false);
+    expect(policyFacetsSchema.safeParse({ category: 'bullying' }).success).toBe(false);
+  });
+
+  it('allows a partial update to omit a facet, but not to set a bad one', () => {
+    expect(policyFacetsSchema.partial().safeParse({ category: 'bullying' }).success).toBe(true);
+    expect(policyFacetsSchema.partial().safeParse({}).success).toBe(true);
+    expect(policyFacetsSchema.partial().safeParse({ category: 'nope' }).success).toBe(false);
   });
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -88,7 +88,6 @@ export const createPromptSchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
   content: z.string().min(10, 'Content is required and must be at least 10 characters'),
   description: z.string().max(500, 'Description is too long').optional(),
-  createdBy: z.string().optional(),
   isActive: z.boolean().default(false),
 });
 
@@ -174,3 +173,23 @@ export function formatValidationErrors(error: z.ZodError): Record<string, string
 
   return formatted;
 }
+
+/**
+ * Parse a policy's jurisdiction and category from an untrusted request.
+ *
+ * Every write path used to take these straight from the body and default the
+ * misses (`|| 'district'`, `|| 'other'`), which is worse than rejecting: a
+ * policy stored under a category retrieval does not match is never returned,
+ * AND -- because assessCoverage queries the same field -- the system then tells
+ * the administrator the district holds no policy for that area. A typo turns a
+ * loaded policy into a reported coverage gap. A bad jurisdiction is worse
+ * still: buildJurisdictionContext groups only over the known four, so the text
+ * is dropped from the model's context while buildCitations still lists it as a
+ * source. Neither may be guessed. (B5)
+ */
+export const policyFacetsSchema = z.object({
+  jurisdiction: jurisdictionEnum,
+  category: categoryEnum,
+});
+
+export type PolicyFacets = z.infer<typeof policyFacetsSchema>;

--- a/src/types/incident-categories.test.ts
+++ b/src/types/incident-categories.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ALWAYS_RETRIEVED_CATEGORY,
   categoriesForIncidentType,
+  guaranteedCategoriesFor,
   INCIDENT_TYPES,
   POLICY_CATEGORIES,
 } from './index';
@@ -60,5 +61,41 @@ describe('categoriesForIncidentType', () => {
     expect(categoriesForIncidentType('title_ix')).toEqual(
       expect.arrayContaining(['title_ix', 'discrimination'])
     );
+  });
+});
+
+describe('guaranteedCategoriesFor', () => {
+  // The search filter and the guaranteed set were once the same function, and
+  // an `other` incident -- the classifier's own failure default -- therefore
+  // retrieved no mandatory-reporting policy AND had its coverage assessment
+  // skipped, so every gap warning was suppressed at the same time. These two
+  // callers must never collapse back into one. (B3)
+
+  it('always includes mandatory reporting, whatever the classification', () => {
+    for (const type of [...INCIDENT_TYPES, 'other']) {
+      expect(guaranteedCategoriesFor(type)).toContain(ALWAYS_RETRIEVED_CATEGORY);
+    }
+  });
+
+  it('includes mandatory reporting for an unclassified incident', () => {
+    expect(guaranteedCategoriesFor(null)).toEqual([ALWAYS_RETRIEVED_CATEGORY]);
+    expect(guaranteedCategoriesFor(undefined)).toEqual([ALWAYS_RETRIEVED_CATEGORY]);
+    expect(guaranteedCategoriesFor('not-a-type')).toEqual([ALWAYS_RETRIEVED_CATEGORY]);
+  });
+
+  it('includes mandatory reporting for `other`, where the search filter is empty', () => {
+    // The empty filter is deliberate: narrowing an unclassified incident to one
+    // category would exclude every other policy. The guarantee is not.
+    expect(categoriesForIncidentType('other')).toEqual([]);
+    expect(guaranteedCategoriesFor('other')).toEqual([ALWAYS_RETRIEVED_CATEGORY]);
+  });
+
+  it('is a superset of the search filter, without duplicates', () => {
+    for (const type of INCIDENT_TYPES) {
+      const filter = categoriesForIncidentType(type);
+      const guaranteed = guaranteedCategoriesFor(type);
+      for (const c of filter) expect(guaranteed).toContain(c);
+      expect(new Set(guaranteed).size).toBe(guaranteed.length);
+    }
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -219,6 +219,28 @@ export function categoriesForIncidentType(
   return [...new Set([...mapped, 'mandatory_reporting' as PolicyCategory])];
 }
 
+/**
+ * The categories that must be represented in the retrieved set and assessed for
+ * coverage, whatever classification returned.
+ *
+ * Deliberately distinct from the search *filter* above. An unclassified or
+ * `other` incident must not constrain the search -- narrowing to one category
+ * would exclude every other policy -- but it must still be guaranteed
+ * mandatory-reporting text, and it must still have its coverage assessed.
+ *
+ * Collapsing the two is how an `other` incident came to retrieve no reporting
+ * policy while suppressing every gap warning at once. `other` is also the
+ * classifier's failure default, so that was the state an incident landed in
+ * precisely when the system knew least about it. (B3)
+ */
+export function guaranteedCategoriesFor(
+  incidentType: string | null | undefined
+): PolicyCategory[] {
+  return [
+    ...new Set([...categoriesForIncidentType(incidentType), ALWAYS_RETRIEVED_CATEGORY]),
+  ];
+}
+
 /** @deprecated Use POLICY_JURISDICTIONS. Retained for existing imports. */
 export enum PolicyType {
   FEDERAL = "federal",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -223,15 +223,10 @@ export function categoriesForIncidentType(
  * The categories that must be represented in the retrieved set and assessed for
  * coverage, whatever classification returned.
  *
- * Deliberately distinct from the search *filter* above. An unclassified or
- * `other` incident must not constrain the search -- narrowing to one category
- * would exclude every other policy -- but it must still be guaranteed
- * mandatory-reporting text, and it must still have its coverage assessed.
- *
- * Collapsing the two is how an `other` incident came to retrieve no reporting
- * policy while suppressing every gap warning at once. `other` is also the
- * classifier's failure default, so that was the state an incident landed in
- * precisely when the system knew least about it. (B3)
+ * Distinct from the search *filter* above, which must stay empty for an
+ * unclassified or `other` incident so it does not exclude every other policy.
+ * Collapsing the two left `other` -- the classifier's failure default -- with
+ * no reporting policy and no gap warning. (B3)
  */
 export function guaranteedCategoriesFor(
   incidentType: string | null | undefined


### PR DESCRIPTION
Draft. Six read-only audit passes over `dev` at `d62eb61`, then remediation in
severity order. **142 findings, 6 blockers. Five fixed, one deferred as a
product decision.**

Full record: [`docs/audit/2026-09-01-findings.md`](docs/audit/2026-09-01-findings.md)
and [`-work-completed.md`](docs/audit/2026-09-01-work-completed.md).

## The one that is not fixed

**Obligation deadlines are invented by the model.** `classifyIncident` is
called with two arguments, so its `policyContext` parameter is `undefined` and
the prompt that produces every `dueInHours` contains no policy text at all —
the model is asked to recall New Hampshire law. `ComplianceAction` has no
`policyId` and no `citation`, so nothing can be reconciled afterwards. Three UI
surfaces told the administrator the deadline came from the policy.

The real fix is a two-phase classification that re-derives obligations after
retrieval and drops any deadline it cannot attribute to an excerpt. That needs
a decision first — **OQ-5: what should the product do when the library cannot
support a deadline?** Suppress the obligation, show it without a countdown, or
show it marked unverified. Each is a different product, so I did not guess.

In the meantime the two UI strings that claimed provenance no longer do, and
README and the roadmap say plainly that deadlines must be confirmed against the
cited policy.

## Fixed

**Guidance correctness.** A policy row with zero chunks used to *cancel* the
coverage gap for its category, so one bad upload silently removed a safety
warning — found independently by three passes. An `other`-classified incident,
which is the classifier's own failure default, retrieved no mandatory-reporting
policy and reported no gap. The summary prompt — whose output is persisted to
the incident file — had no retrieval guard and still named `"JICK"`, `"ACAC"`,
`"JLF"` as exemplars, which is exactly what the chat path was fixed for. The
coverage card printed *"It is sound"* over guidance whose authority may not
exist.

**Security.** `POST /api/admin/prompts` read `createdBy` from the request body
— the named invariant, and the last such route. No admin mutation wrote an
audit record; all eight now do, and the prompt update captures the previous
content so a change to mandated-reporting advice is reconstructable.

**Tests that could not fail.** Three tests named an invariant and asserted
something else. Each fix was verified by reintroducing the defect:

- dropping `incidentScope` from `obligations/[id]` lets any reporter discharge
  any obligation in the district — old test passed, new test 404 vs 200
- dropping `incidentScope` from `incidents/[id]` GET and PATCH lets every
  reporter read and rewrite every incident — that is SEC-7 — old test passed
  because it only re-checked the *list*
- reverting the coverage fix makes `school_safety` gain phantom coverage —
  verified the new assertion fails

Also: admin API authorization had no test at all, and `reuseExistingServer`
meant the suite could silently run against the real API and production data.

**Real bugs found while writing those tests.** `describeDeadline` rendered
`in 60m` and `in 23h 60m` in the last 30 seconds of every hour. Chat 503'd
intermittently past 20 messages because the history window could begin on an
assistant turn. 120 references to 13 CSS custom properties that no stylesheet
defines — verified absent from the built CSS — so user message bubbles rendered
with no background and the 44px touch target was missing from every button.

## Gates

| | before | after |
|---|---|---|
| typecheck | 0 errors | 0 errors |
| lint | 0 errors, 3 warnings | 0 errors, 3 warnings |
| build | ✓ | ✓ (clean `.next`) |
| unit | 97 | **110** |
| e2e | 52 | **53** |

No suppressions introduced — verified across the whole diff. `tsconfig.json`,
`eslint.config.mjs` and `.github/` untouched. One assertion was removed,
`expect(Array.isArray(obligations)).toBe(true)`, which passed for any
successful GET; it is replaced by a real check. Nothing was deleted whose
behaviour is not covered by a test or spec line.

## Deferred

SEC-19 (no way to revoke a user's access), SEC-22/SEC-23/SEC-25 (upload
buffering, rate limiting, prompt injection via the system prompt), FLOW-37
(retrieval ranks by recency before relevance), and the docs findings —
`POLICY_MAPPING.md` and `QUICK_START_POLICY_UPLOAD.md` still advertise the
deactivated fabricated `DISC-001` as loaded. All recorded in the findings.

Left as a draft: a blocker is unresolved and OQ-5 is yours to settle.