### PR TITLE
Deploy to Azure Container Apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# The build context is uploaded to the daemon and `COPY . .` lands in the
+# builder layer, so anything here that is secret or student-record material
+# leaks into an image someone may push to a registry.
+
+# Credentials. .env holds the production DATABASE_URL and API keys.
+.env
+.env.*
+!.env.example
+
+# Student records. Attachments and policy source documents live here; they are
+# runtime state on a mounted volume, never part of an image.
+uploads/
+data/
+
+# Rebuilt inside the image.
+node_modules/
+.next/
+src/generated/
+
+# Never needed at runtime.
+.git/
+.github/
+.claude/
+docs/
+e2e/
+test-results/
+playwright-report/
+sample-policies/
+*.md
+!README.md
+
+# Local noise.
+.DS_Store
+*.tsbuildinfo
+.vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ src/generated/
 *.tmp
 *.temp
 e2e/.auth/
+
+# Azure deployment config: names, and the only copy of the DB password.
+deploy/azure/.env
+deploy/azure/.provisioned

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # container entrypoint (SEC-14), which sets NODE_ENV=development and so turned
 # three "development only" error-detail guards into live disclosure in the
 # deployed container, enabled the dev overlay and source maps, and enabled the
-# hot reload that turned an arbitrary file write into RCE. Node was also pinned
-# to 18, which is end-of-life and inconsistent with the rest of the repo.
+# hot reload that turned an arbitrary file write into RCE.
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
@@ -15,25 +14,66 @@ WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Generate inside the image: the query engine is platform-specific, and the one
+# committed by a developer's machine is for their platform, not linux-musl.
 RUN npx prisma generate && npm run build
+
+# ---------------------------------------------------------------------------
+# Migration runner. A separate target, not a step in the app's entrypoint.
+#
+# The Prisma CLI needs its own transitive dependencies, which the standalone
+# tree does not carry -- shipping them would put the whole CLI and its
+# dependency graph into the production image for the sake of one command that
+# runs once per deploy.
+#
+# Splitting it also removes a race: N replicas starting together would each
+# attempt the same migration. Run this as a job before rolling the app
+# revision, so the schema is never behind the code. This repo has already had
+# one production outage from that ordering -- a re-index ran against a database
+# missing a column, deleted every policy chunk, could not write the
+# replacements, and retrieval silently returned nothing.
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS migrator
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/src/generated ./src/generated
+COPY prisma ./prisma
+COPY package*.json tsconfig.json ./
+# src and scripts as well, so this doubles as the ops image. The app image is
+# deliberately too lean to run them, and the operational commands this system
+# needs -- create-user, policies:load, policies:coverage, policies:reindex --
+# have to run somewhere against the real database.
+COPY src ./src
+COPY scripts ./scripts
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001 && chown -R nextjs:nodejs /app
+USER nextjs
+CMD ["npx", "prisma", "migrate", "deploy"]
 
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
 
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/prisma ./prisma
-COPY --from=builder /app/src/generated ./src/generated
+# The standalone tree carries its own traced node_modules and server.js.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
-# Uploads must be a writable volume, not part of the image.
+# The generated client and its linux-musl query engine. Standalone tracing does
+# not reliably carry the .node binary, so it is copied explicitly.
+COPY --from=builder --chown=nextjs:nodejs /app/src/generated ./src/generated
+
+# Uploads are attachments and policy source documents -- student-record
+# material and re-index provenance. This directory must be a mounted volume in
+# any real deployment; the mkdir only makes the container start cleanly when it
+# is not, and anything written to it then dies with the container.
 RUN mkdir -p uploads && chown -R nextjs:nodejs uploads
 
 USER nextjs
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/deploy/azure/containerapp.template.yaml
+++ b/deploy/azure/containerapp.template.yaml
@@ -1,0 +1,89 @@
+# Rendered by deploy.sh (envsubst) and applied with `az containerapp create/update --yaml`.
+#
+# Declarative because volume mounts and probes cannot be expressed with the
+# imperative `az containerapp` flags, and because a deployment you can read in
+# one file is one you can review.
+location: ${LOCATION}
+properties:
+  managedEnvironmentId: ${ENVIRONMENT_ID}
+  configuration:
+    activeRevisionsMode: Single
+    ingress:
+      external: true
+      targetPort: 3000
+      transport: auto
+      allowInsecure: false
+    registries:
+      - server: ${ACR_SERVER}
+        username: ${ACR_USER}
+        passwordSecretRef: acr-password
+    secrets:
+      - name: acr-password
+        value: ${ACR_PASS}
+      - name: database-url
+        value: ${DATABASE_URL}
+      - name: auth-secret
+        value: ${AUTH_SECRET}
+      - name: anthropic-key
+        value: ${ANTHROPIC_API_KEY}
+  template:
+    containers:
+      - name: app
+        image: ${APP_IMAGE}
+        resources:
+          cpu: 1.0
+          memory: 2Gi
+        env:
+          - name: DATABASE_URL
+            secretRef: database-url
+          - name: AUTH_SECRET
+            secretRef: auth-secret
+          - name: ANTHROPIC_API_KEY
+            secretRef: anthropic-key
+          # https, not the forwarded protocol: the ingress terminates TLS and
+          # the app sees plain http, and this value is what decides whether the
+          # session cookie is issued Secure. (SEC-28)
+          - name: NEXTAUTH_URL
+            value: https://${APP_FQDN}
+          - name: AUTH_TRUST_HOST
+            value: "true"
+          - name: UPLOADS_DIR
+            value: /app/uploads
+          - name: NODE_ENV
+            value: production
+        volumeMounts:
+          # Attachments are student records; policy source files are what
+          # `policies:reindex` re-extracts from. Both are runtime state. Without
+          # this mount they live in the container's writable layer and are
+          # destroyed on every revision, restart and scale event.
+          - volumeName: uploads
+            mountPath: /app/uploads
+        probes:
+          # Liveness only, and deliberately not a database check: a probe that
+          # fails when Postgres blips makes the platform restart a process that
+          # is working, turning a short outage into a restart loop.
+          - type: Liveness
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            failureThreshold: 3
+          - type: Readiness
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+    scale:
+      # One replica, deliberately. Scale-to-zero would make an administrator
+      # wait through a cold start mid-incident, and more than one replica needs
+      # the uploads share to be genuinely concurrent-safe and the session store
+      # to be shared — neither has been established. Revisit with evidence.
+      minReplicas: 1
+      maxReplicas: 1
+    volumes:
+      - name: uploads
+        storageType: AzureFile
+        storageName: ${STORAGE_MOUNT_NAME}

--- a/deploy/azure/deploy.sh
+++ b/deploy/azure/deploy.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Build, push, migrate, then roll the app. Run on every code change.
+#
+# Order matters: migrations are applied by a job that runs to completion BEFORE
+# the new revision serves traffic. The schema must never be behind the code.
+# This repo has already had one production outage from that ordering — a
+# re-index ran against a database missing a column, deleted every policy chunk,
+# could not write the replacements, and retrieval silently returned nothing.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+[ -f .env ] || { echo "deploy/azure/.env not found. Run provision.sh first." >&2; exit 1; }
+# shellcheck disable=SC1091
+source .env
+[ -f .provisioned ] || { echo ".provisioned not found. Run provision.sh first." >&2; exit 1; }
+# shellcheck disable=SC1091
+source .provisioned
+
+REPO_ROOT="$(cd ../.. && pwd)"
+TAG="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ] || TAG="${TAG}-dirty"
+
+ACR_SERVER="$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query loginServer -o tsv)"
+APP_IMAGE="${ACR_SERVER}/${APP_NAME}:${TAG}"
+MIGRATE_IMAGE="${ACR_SERVER}/${APP_NAME}-migrate:${TAG}"
+
+echo "==> building for linux/amd64 (Container Apps does not run arm64 images)"
+az acr login -n "$ACR_NAME"
+docker build --platform linux/amd64 -t "$APP_IMAGE" "$REPO_ROOT"
+docker build --platform linux/amd64 --target migrator -t "$MIGRATE_IMAGE" "$REPO_ROOT"
+docker push "$APP_IMAGE"
+docker push "$MIGRATE_IMAGE"
+
+ACR_USER="$(az acr credential show -n "$ACR_NAME" --query username -o tsv)"
+ACR_PASS="$(az acr credential show -n "$ACR_NAME" --query 'passwords[0].value' -o tsv)"
+
+echo "==> applying migrations (job runs to completion before the app rolls)"
+if ! az containerapp job show -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" -o none 2>/dev/null; then
+  az containerapp job create \
+    -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" --environment "$ENVIRONMENT_NAME" \
+    --trigger-type Manual --replica-timeout 600 --replica-retry-limit 1 \
+    --image "$MIGRATE_IMAGE" --cpu 0.5 --memory 1Gi \
+    --registry-server "$ACR_SERVER" --registry-username "$ACR_USER" --registry-password "$ACR_PASS" \
+    --secrets "database-url=$DATABASE_URL" \
+    --env-vars "DATABASE_URL=secretref:database-url" -o none
+else
+  az containerapp job update \
+    -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" --image "$MIGRATE_IMAGE" -o none
+fi
+
+EXECUTION="$(az containerapp job start -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" --query name -o tsv)"
+echo "    execution: $EXECUTION"
+for _ in $(seq 1 60); do
+  STATUS="$(az containerapp job execution show -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" \
+            --job-execution-name "$EXECUTION" --query properties.status -o tsv 2>/dev/null || echo Running)"
+  case "$STATUS" in
+    Succeeded) echo "    migrations applied"; break ;;
+    Failed|Degraded)
+      echo "    MIGRATION FAILED — not rolling the app. Logs:" >&2
+      az containerapp job logs show -g "$RESOURCE_GROUP" -n "$MIGRATE_JOB_NAME" \
+        --execution "$EXECUTION" --tail 100 >&2 || true
+      exit 1 ;;
+  esac
+  sleep 5
+done
+[ "${STATUS:-}" = "Succeeded" ] || { echo "    migration job did not finish in time; not rolling the app" >&2; exit 1; }
+
+echo "==> app"
+ENVIRONMENT_ID="$(az containerapp env show -g "$RESOURCE_GROUP" -n "$ENVIRONMENT_NAME" --query id -o tsv)"
+
+# The FQDN is only knowable once the app exists, and NEXTAUTH_URL needs it. On
+# the first run, create with a placeholder, read the FQDN, then apply again.
+APP_FQDN="$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP_NAME" \
+            --query properties.configuration.ingress.fqdn -o tsv 2>/dev/null || echo '')"
+
+render() {
+  export LOCATION ENVIRONMENT_ID ACR_SERVER ACR_USER ACR_PASS DATABASE_URL \
+         AUTH_SECRET ANTHROPIC_API_KEY APP_IMAGE APP_FQDN STORAGE_MOUNT_NAME
+  envsubst < containerapp.template.yaml > "$1"
+}
+
+RENDERED="$(mktemp)"
+trap 'rm -f "$RENDERED"' EXIT
+
+if [ -z "$APP_FQDN" ]; then
+  APP_FQDN="placeholder.invalid"
+  render "$RENDERED"
+  az containerapp create -g "$RESOURCE_GROUP" -n "$CONTAINER_APP_NAME" --yaml "$RENDERED" -o none
+  APP_FQDN="$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP_NAME" \
+              --query properties.configuration.ingress.fqdn -o tsv)"
+  echo "    first run: re-applying with NEXTAUTH_URL=https://${APP_FQDN}"
+fi
+
+render "$RENDERED"
+az containerapp update -g "$RESOURCE_GROUP" -n "$CONTAINER_APP_NAME" --yaml "$RENDERED" -o none
+
+echo
+echo "Deployed: https://${APP_FQDN}"
+echo "Health:   https://${APP_FQDN}/api/health"
+echo
+echo "First deploy only — create the admin user with the ops image:"
+echo "  ./ops.sh user:create -- --email you@example.org --name 'Your Name' --role admin"

--- a/deploy/azure/env.example
+++ b/deploy/azure/env.example
@@ -1,0 +1,34 @@
+# Copy to deploy/azure/.env and edit. Sourced by provision.sh and deploy.sh.
+# This file is gitignored; it holds names, not secrets.
+
+# Must be globally unique-ish: the app's hostname is derived from it.
+export APP_NAME="generalschat"
+export LOCATION="eastus"
+export RESOURCE_GROUP="rg-${APP_NAME}"
+
+# Registry names must be 5-50 alphanumeric characters, globally unique.
+export ACR_NAME="acrgeneralschat"
+
+export ENVIRONMENT_NAME="cae-${APP_NAME}"
+export CONTAINER_APP_NAME="ca-${APP_NAME}"
+export MIGRATE_JOB_NAME="job-${APP_NAME}-migrate"
+
+# Postgres Flexible Server. The name becomes <name>.postgres.database.azure.com.
+export PG_SERVER_NAME="pg-${APP_NAME}"
+export PG_ADMIN_USER="gcadmin"
+export PG_DATABASE="generalschat"
+# Leave unset and provision.sh generates one and prints it once.
+export PG_ADMIN_PASSWORD=""
+
+# Azure Files share backing /app/uploads. Attachments are student records; if
+# this is not mounted they are destroyed on every revision.
+export STORAGE_ACCOUNT="st${APP_NAME}$RANDOM"
+export FILE_SHARE="uploads"
+export STORAGE_MOUNT_NAME="uploadsmount"
+
+# Application secrets. Generate AUTH_SECRET with: openssl rand -base64 32
+export AUTH_SECRET=""
+export ANTHROPIC_API_KEY=""
+
+# Optional: enables vector search instead of the keyword fallback.
+export OPENAI_API_KEY=""

--- a/deploy/azure/ops.sh
+++ b/deploy/azure/ops.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Run an operational command against the deployed database.
+#
+#   ./ops.sh user:create -- --email you@example.org --name 'You' --role admin
+#   ./ops.sh policies:coverage
+#   ./ops.sh policies:reindex -- --apply
+#
+# Uses the migrator image, which carries src/ and scripts/; the app image is
+# deliberately too lean to run these.
+#
+# These write to the pilot's real database. `policies:reindex` without --apply
+# is a dry run, and that is the right way to start.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+# shellcheck disable=SC1091
+source .env
+# shellcheck disable=SC1091
+source .provisioned
+
+[ $# -gt 0 ] || { sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'; exit 1; }
+
+ACR_SERVER="$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query loginServer -o tsv)"
+TAG="$(git -C ../.. rev-parse --short HEAD)"
+IMAGE="${ACR_SERVER}/${APP_NAME}-migrate:${TAG}"
+JOB="job-${APP_NAME}-ops"
+ACR_USER="$(az acr credential show -n "$ACR_NAME" --query username -o tsv)"
+ACR_PASS="$(az acr credential show -n "$ACR_NAME" --query 'passwords[0].value' -o tsv)"
+
+CMD_ARGS=$(printf '"%s",' npm run "$@" | sed 's/,$//')
+
+az containerapp job delete -g "$RESOURCE_GROUP" -n "$JOB" --yes -o none 2>/dev/null || true
+az containerapp job create \
+  -g "$RESOURCE_GROUP" -n "$JOB" --environment "$ENVIRONMENT_NAME" \
+  --trigger-type Manual --replica-timeout 1800 --replica-retry-limit 0 \
+  --image "$IMAGE" --cpu 1 --memory 2Gi \
+  --registry-server "$ACR_SERVER" --registry-username "$ACR_USER" --registry-password "$ACR_PASS" \
+  --secrets "database-url=$DATABASE_URL" "anthropic-key=${ANTHROPIC_API_KEY}" \
+  --env-vars "DATABASE_URL=secretref:database-url" "ANTHROPIC_API_KEY=secretref:anthropic-key" \
+  --command "[$CMD_ARGS]" -o none
+
+EXEC="$(az containerapp job start -g "$RESOURCE_GROUP" -n "$JOB" --query name -o tsv)"
+echo "running: npm run $* (execution $EXEC)"
+for _ in $(seq 1 360); do
+  STATUS="$(az containerapp job execution show -g "$RESOURCE_GROUP" -n "$JOB" \
+            --job-execution-name "$EXEC" --query properties.status -o tsv 2>/dev/null || echo Running)"
+  [ "$STATUS" = "Running" ] || break
+  sleep 5
+done
+az containerapp job logs show -g "$RESOURCE_GROUP" -n "$JOB" --execution "$EXEC" --tail 200 || true
+echo "status: ${STATUS:-unknown}"
+[ "${STATUS:-}" = "Succeeded" ]

--- a/deploy/azure/provision.sh
+++ b/deploy/azure/provision.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Create the Azure resources this app needs. Safe to re-run: every step either
+# creates or reports that the resource already exists.
+#
+# Run once per environment. deploy.sh is what you run on every code change.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+[ -f .env ] || { echo "deploy/azure/.env not found. Copy env.example to .env and edit it." >&2; exit 1; }
+# shellcheck disable=SC1091
+source .env
+
+require() { [ -n "${!1:-}" ] || { echo "$1 must be set in deploy/azure/.env" >&2; exit 1; }; }
+for v in APP_NAME LOCATION RESOURCE_GROUP ACR_NAME ENVIRONMENT_NAME CONTAINER_APP_NAME \
+         MIGRATE_JOB_NAME PG_SERVER_NAME PG_ADMIN_USER PG_DATABASE STORAGE_ACCOUNT \
+         FILE_SHARE STORAGE_MOUNT_NAME AUTH_SECRET ANTHROPIC_API_KEY; do require "$v"; done
+
+az extension add --name containerapp --upgrade --only-show-errors >/dev/null
+az provider register --namespace Microsoft.App --wait >/dev/null
+az provider register --namespace Microsoft.OperationalInsights --wait >/dev/null
+
+echo "==> resource group"
+az group create -n "$RESOURCE_GROUP" -l "$LOCATION" -o none
+
+echo "==> container registry"
+az acr create -g "$RESOURCE_GROUP" -n "$ACR_NAME" --sku Basic --admin-enabled true -o none
+
+echo "==> postgres flexible server"
+if [ -z "${PG_ADMIN_PASSWORD:-}" ]; then
+  PG_ADMIN_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=' | head -c 24)Aa1!"
+  echo "    generated Postgres admin password (store this now, it is not shown again):"
+  echo "    $PG_ADMIN_PASSWORD"
+fi
+az postgres flexible-server create \
+  -g "$RESOURCE_GROUP" -n "$PG_SERVER_NAME" -l "$LOCATION" \
+  --admin-user "$PG_ADMIN_USER" --admin-password "$PG_ADMIN_PASSWORD" \
+  --tier Burstable --sku-name Standard_B1ms --storage-size 32 \
+  --version 16 --public-access 0.0.0.0 --yes -o none 2>/dev/null || echo "    exists"
+az postgres flexible-server db create \
+  -g "$RESOURCE_GROUP" -s "$PG_SERVER_NAME" -d "$PG_DATABASE" -o none 2>/dev/null || true
+
+# --public-access 0.0.0.0 allows Azure services only, not the internet. Add
+# your own address explicitly if you want to connect psql from your machine.
+echo "==> storage for uploads (student records — must outlive any revision)"
+az storage account create \
+  -g "$RESOURCE_GROUP" -n "$STORAGE_ACCOUNT" -l "$LOCATION" \
+  --sku Standard_LRS --kind StorageV2 --min-tls-version TLS1_2 -o none 2>/dev/null || echo "    exists"
+STORAGE_KEY="$(az storage account keys list -g "$RESOURCE_GROUP" -n "$STORAGE_ACCOUNT" --query '[0].value' -o tsv)"
+az storage share-rm create \
+  -g "$RESOURCE_GROUP" --storage-account "$STORAGE_ACCOUNT" -n "$FILE_SHARE" --quota 64 -o none 2>/dev/null || true
+
+echo "==> container apps environment"
+az containerapp env create \
+  -g "$RESOURCE_GROUP" -n "$ENVIRONMENT_NAME" -l "$LOCATION" -o none 2>/dev/null || echo "    exists"
+
+echo "==> attach the file share to the environment"
+az containerapp env storage set \
+  -g "$RESOURCE_GROUP" -n "$ENVIRONMENT_NAME" \
+  --storage-name "$STORAGE_MOUNT_NAME" \
+  --azure-file-account-name "$STORAGE_ACCOUNT" \
+  --azure-file-account-key "$STORAGE_KEY" \
+  --azure-file-share-name "$FILE_SHARE" \
+  --access-mode ReadWrite -o none
+
+cat > .provisioned <<EOF
+export PG_ADMIN_PASSWORD='${PG_ADMIN_PASSWORD}'
+export DATABASE_URL='postgresql://${PG_ADMIN_USER}:${PG_ADMIN_PASSWORD}@${PG_SERVER_NAME}.postgres.database.azure.com:5432/${PG_DATABASE}?sslmode=require'
+EOF
+chmod 600 .provisioned
+
+echo
+echo "Provisioned. Connection details written to deploy/azure/.provisioned (chmod 600)."
+echo "Next: ./deploy.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,14 +23,28 @@ services:
       timeout: 5s
       retries: 10
 
+  # Migrations run to completion before the app starts, the same ordering the
+  # Azure deploy uses. The app image is lean and carries no Prisma CLI.
+  migrate:
+    build:
+      context: .
+      target: migrator
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/generalschat?schema=public
+    depends_on:
+      db:
+        condition: service_healthy
+
   app:
     build: .
     ports:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/generalschat?schema=public
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}
-      AUTH_SECRET: ${AUTH_SECRET:?AUTH_SECRET must be set - generate with: openssl rand -base64 32}
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}"
+      # Quoted: the message contains ': ', which makes an unquoted value invalid
+      # YAML. This file had never parsed, so `docker compose up` had never run.
+      AUTH_SECRET: "${AUTH_SECRET:?AUTH_SECRET must be set - generate with openssl rand -base64 32}"
       NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       AUTH_TRUST_HOST: "true"
       # Optional: enables vector search instead of the keyword fallback.
@@ -42,6 +56,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
 volumes:
   postgres_data:

--- a/docs/deploy-azure.md
+++ b/docs/deploy-azure.md
@@ -1,0 +1,132 @@
+# Deploying to Azure
+
+Target: **Azure Container Apps**, with **Azure Database for PostgreSQL Flexible
+Server** and an **Azure Files** share for uploads.
+
+Why Container Apps rather than App Service or AKS: the app is one container
+with one replica for a single-tenant pilot. Container Apps gives managed TLS, a
+container registry integration, secrets, and jobs — which is what the migration
+and operational commands need — without the cluster that AKS would make you
+own. App Service for Containers would also work; it has no first-class job
+primitive, so migrations and `policies:*` would need another home.
+
+## What you need first
+
+- `az` CLI, logged in (`az login`) against the subscription you want billed
+- Docker running locally (the images are built on your machine and pushed)
+- An Anthropic API key
+
+## One-time
+
+```bash
+cp deploy/azure/env.example deploy/azure/.env
+# edit deploy/azure/.env — at minimum ACR_NAME, STORAGE_ACCOUNT (both must be
+# globally unique), AUTH_SECRET and ANTHROPIC_API_KEY
+openssl rand -base64 32        # for AUTH_SECRET
+
+./deploy/azure/provision.sh
+```
+
+`provision.sh` creates the resource group, registry, Postgres server, storage
+account and file share, and the Container Apps environment. It is safe to
+re-run. It writes `deploy/azure/.provisioned` (mode 600) holding the generated
+Postgres password and the assembled `DATABASE_URL` — **that file is the only
+copy of the database password**, and it is gitignored.
+
+## Every deploy
+
+```bash
+./deploy/azure/deploy.sh
+```
+
+It builds both images for `linux/amd64`, pushes them, **runs migrations as a
+job and waits for it to succeed**, and only then rolls the app revision. If the
+migration fails it prints the logs and stops without touching the running app.
+
+That ordering is deliberate. This repo has already had one production outage
+from the schema being behind the code: a re-index ran against a database
+missing a column, deleted every policy chunk, could not write the replacements,
+and retrieval silently returned nothing while the app looked healthy.
+
+## Creating the first admin, and other operational commands
+
+The app image is deliberately lean — 94MB, standalone Next.js output, no Prisma
+CLI and no `scripts/`. The migrator image carries `src/` and `scripts/` and
+doubles as the ops image:
+
+```bash
+./deploy/azure/ops.sh user:create -- --email you@example.org --name 'You' --role admin
+./deploy/azure/ops.sh policies:coverage
+./deploy/azure/ops.sh policies:load -- --file /tmp/JICK.pdf --title '...' --jurisdiction district --category bullying --effective 2026-07-01 --apply
+./deploy/azure/ops.sh policies:reindex            # dry run
+./deploy/azure/ops.sh policies:reindex -- --apply
+```
+
+`user:create` prints a generated password once. Store it immediately.
+
+These run against the real database. `policies:reindex` without `--apply` is a
+dry run, and that is how to start — see `CLAUDE.md` on why.
+
+## Things that will bite you if you change them
+
+**The uploads mount is not optional.** `/app/uploads` holds attachments —
+student records — and the policy source files `policies:reindex` re-extracts
+from. Container filesystems are ephemeral: without the Azure Files volume in
+`containerapp.template.yaml`, every attachment an administrator uploads is
+destroyed on the next deploy, restart or scale event, and the app will report
+no error at any point. The mount is the only thing making that storage real.
+
+**`NEXTAUTH_URL` must be the `https://` URL.** The ingress terminates TLS and
+forwards plain http, so the app cannot tell it was an https request. That value
+is what decides whether the session cookie is issued `Secure` and with the
+`__Secure-` prefix (`shouldUseSecureCookies` in `src/auth.config.ts`). Set it to
+http, or leave it unset, and you issue an unprotected session cookie for an
+application holding Title IX files about minors — and nothing in the app will
+tell you. `deploy.sh` sets it from the app's own FQDN, which is why the first
+run applies the config twice.
+
+**One replica, deliberately.** `minReplicas: 1` and `maxReplicas: 1`.
+Scale-to-zero would make an administrator wait through a cold start in the
+middle of an incident. More than one replica needs two things that have not
+been established: that concurrent writes to the Azure Files share are safe, and
+that migrations are not racing (they are not — they run as a job — but
+`RUN_MIGRATIONS`-style startup migrations would). Raise it with evidence, not
+by default.
+
+**Postgres is reachable from Azure services only.** `provision.sh` uses
+`--public-access 0.0.0.0`, which despite the notation means "Azure services",
+not the internet. To connect `psql` from your own machine, add your address
+explicitly:
+
+```bash
+az postgres flexible-server firewall-rule create -g rg-generalschat \
+  -n pg-generalschat --rule-name me --start-ip-address <your-ip> --end-ip-address <your-ip>
+```
+
+**`sslmode=require` is in the connection string** and Azure Postgres will
+refuse the connection without it.
+
+## Costs, roughly
+
+Burstable `Standard_B1ms` Postgres, one 1-vCPU Container App replica held at
+minimum 1, a Basic registry and a 64GB file share. This is the small end of
+each; the always-on replica is the largest line. Scale-to-zero would cut it and
+costs an administrator a cold start mid-incident — a deliberate trade, not an
+oversight.
+
+## What this does not set up
+
+- **A custom domain and certificate.** Container Apps gives you an
+  `azurecontainerapps.io` hostname with TLS. A district domain needs
+  `az containerapp hostname add` plus a managed certificate, and
+  `NEXTAUTH_URL` updated to match — the cookie depends on it.
+- **Backups beyond the Postgres default.** Flexible Server takes automatic
+  backups with a 7-day retention by default. The Azure Files share holding
+  student records has **no backup configured**. Decide that before the pilot
+  holds anything real.
+- **Log retention and alerting.** Container Apps sends stdout to Log Analytics
+  in the environment; nothing alerts on anything.
+- **Rate limiting.** Still open from the audit (SEC-11/SEC-23). The credentials
+  endpoint is public and unthrottled, and `bcrypt` at cost 12 blocks the event
+  loop for ~0.25s per attempt. Worth closing before this is reachable from the
+  open internet by anyone who knows the hostname.

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -62,6 +62,19 @@ test.describe('Navigation', () => {
     }
   });
 
+  test('the health probe is reachable without a session and says nothing else', async ({
+    browser,
+  }) => {
+    // Container platforms probe without credentials, so this is the one route
+    // outside the deny-by-default gate. It must stay reachable, and it must
+    // stay uninformative -- no version, no environment, no dependency status.
+    const anonymous = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+    const response = await anonymous.request.get('/api/health');
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok' });
+    await anonymous.close();
+  });
+
   test('signing out ends the session', async ({ page, context }) => {
     await page.goto('/');
     await page.getByText('Settings').click();

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Emits .next/standalone with only the traced runtime dependencies, which
+  // takes the deployed image from ~1.5GB to a couple of hundred MB. On a
+  // container platform that is cold-start time and registry cost on every
+  // revision. `next start` still works locally -- the standalone tree is
+  // produced alongside the normal build, not instead of it.
+  output: 'standalone',
+
   // ESLint runs as part of `next build`. It was previously disabled here
   // ("ignoreDuringBuilds: true, for MVP"), which -- combined with a `lint`
   // script that scanned an untracked stray directory and CI that never ran

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Liveness probe for the container platform.
+ *
+ * Deliberately unauthenticated — a probe carries no session — and deliberately
+ * says nothing. No version, no environment, no dependency status: this is the
+ * one route reachable without signing in to an application holding incident
+ * records about minors, so it must not become a reconnaissance surface.
+ *
+ * Also deliberately does NOT touch the database. A liveness probe that fails
+ * when Postgres is briefly unreachable makes the platform kill and restart a
+ * process that is working, turning a short database blip into a restart loop
+ * that lasts as long as the blip. The question this answers is "is the Node
+ * process serving HTTP", which is the only question a restart can fix.
+ */
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/auth.config.test.ts
+++ b/src/auth.config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUseSecureCookies } from './auth.config';
+
+/**
+ * Which cookie the app issues is decided here, and getting it wrong issues an
+ * unprotected session cookie for an application holding Title IX files about
+ * minors — with nothing in the app reporting it. (SEC-28)
+ */
+describe('shouldUseSecureCookies', () => {
+  it('is secure when the deployment declares https', () => {
+    expect(shouldUseSecureCookies('https://generalschat.example.org')).toBe(true);
+    expect(shouldUseSecureCookies('HTTPS://GeneralsChat.Example.Org')).toBe(true);
+  });
+
+  it('is not secure over plain http', () => {
+    // The e2e suite runs a production build over http; a __Secure- cookie is
+    // rejected outright there, which would break auth for a reason unrelated
+    // to the code under test.
+    expect(shouldUseSecureCookies('http://localhost:3100')).toBe(false);
+  });
+
+  it('is not secure when nothing is declared', () => {
+    // Fails closed on the cookie name rather than issuing a __Secure- cookie
+    // the browser will then refuse to store.
+    expect(shouldUseSecureCookies(undefined)).toBe(false);
+    expect(shouldUseSecureCookies('')).toBe(false);
+    expect(shouldUseSecureCookies('   ')).toBe(false);
+  });
+
+  it('is not fooled by https appearing elsewhere in the value', () => {
+    expect(shouldUseSecureCookies('http://example.org/?next=https://elsewhere')).toBe(false);
+  });
+});

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -11,8 +11,13 @@ import type { NextAuthConfig } from 'next-auth';
  * Node-runtime route handler.
  */
 
-/** Routes reachable without a session. Everything else is denied by default. */
-const PUBLIC_PATHS = ['/login', '/about'];
+/**
+ * Routes reachable without a session. Everything else is denied by default.
+ *
+ * `/api/health` is here because a container platform's probe has no session.
+ * It returns a fixed `{status:'ok'}` and reads nothing.
+ */
+const PUBLIC_PATHS = ['/login', '/about', '/api/health'];
 
 function isPublicPath(pathname: string): boolean {
   if (PUBLIC_PATHS.includes(pathname)) return true;
@@ -24,6 +29,28 @@ function isPublicPath(pathname: string): boolean {
 function isAdminPath(pathname: string): boolean {
   return pathname.startsWith('/admin') || pathname.startsWith('/api/admin');
 }
+
+/**
+ * Whether to issue the session cookie as Secure, taken from the URL the
+ * deployment declares for itself rather than from the protocol of the request.
+ *
+ * Behind a platform ingress that terminates TLS -- Azure Container Apps, and
+ * every other managed container host -- the app sees plain http even though
+ * the browser spoke https, so deriving from the request marks the cookie
+ * insecure on a site that is in fact secure. Deriving from NODE_ENV is worse
+ * in the other direction: the e2e suite runs a production build over http, and
+ * a __Secure- cookie is rejected outright there, so auth would break in tests
+ * for a reason that has nothing to do with the code under test.
+ *
+ * The declared URL is the one signal that is true in both places. (SEC-28)
+ */
+export function shouldUseSecureCookies(declaredUrl: string | undefined): boolean {
+  return (declaredUrl ?? '').trim().toLowerCase().startsWith('https://');
+}
+
+const useSecureCookies = shouldUseSecureCookies(
+  process.env.NEXTAUTH_URL ?? process.env.AUTH_URL
+);
 
 export const authConfig = {
   pages: {
@@ -41,6 +68,18 @@ export const authConfig = {
      */
     maxAge: 30 * 60,
     updateAge: 5 * 60,
+  },
+  /* Pinned, not derived from the request protocol. See useSecureCookies. */
+  cookies: {
+    sessionToken: {
+      name: useSecureCookies ? '__Secure-authjs.session-token' : 'authjs.session-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+      },
+    },
   },
   callbacks: {
     /**


### PR DESCRIPTION
Azure Container Apps + Postgres Flexible Server + an Azure Files share for
uploads. Full walkthrough in [`docs/deploy-azure.md`](docs/deploy-azure.md).

```bash
cp deploy/azure/env.example deploy/azure/.env   # edit
./deploy/azure/provision.sh                      # one-time
./deploy/azure/deploy.sh                         # every change
./deploy/azure/ops.sh user:create -- --email you@example.org --role admin
```

Container Apps over App Service because migrations and the `policies:*`
commands need a job primitive; over AKS because this is one container with one
replica.

## Four things this had to fix rather than configure

**`.dockerignore` did not exist.** `COPY . .` put `.env` — holding the
production `DATABASE_URL` — into the builder layer, along with `uploads/`,
which is student records. Neither reaches the final image through the
multi-stage build, but both were in the build context and in a cached layer.

**The image was ~1.5GB.** Standalone output plus an explicit copy of the Prisma
client and its linux-musl engine takes the app image to **94MB**.

**Migrations needed somewhere to run.** The Prisma CLI needs transitive deps
the standalone tree doesn't carry, and shipping them would put the whole CLI
dependency graph in the production image for one command per deploy. A separate
`migrator` target runs as a job that must succeed *before* the app rolls —
which also removes the race a startup migration would have across replicas. It
carries `src/` and `scripts/`, so it doubles as the ops image; the app image is
too lean to run `user:create` or `policies:load`, and those have to run
somewhere.

**`docker-compose.yml` had never parsed.** The `AUTH_SECRET` line's error
message contains `': '`, which makes an unquoted YAML value invalid — so
`docker compose up` has never worked, on any branch. Quoted, and given a
`migrate` service so the local stack matches the deploy ordering.

## Also closes SEC-28

The audit left it open pending exactly this decision. Behind an ingress that
terminates TLS the app sees plain http, so `@auth/core` would derive a
*non-Secure* cookie on a site that is in fact secure. Deriving from `NODE_ENV`
instead breaks the e2e suite, which runs a production build over http and would
have its `__Secure-` cookie rejected outright. `shouldUseSecureCookies` reads
the URL the deployment declares for itself, which is the one signal true in
both places. Four unit tests.

## Verified, not assumed

Built the image and booted it against a real Postgres:

- `/api/health` → 200 `{"status":"ok"}`
- `/api/incidents` with no session → **401**
- `/login` → 200, `/` → 307

so the deny-by-default gate holds in the production image. Ran the migrator
against a fresh database (all migrations applied) and `user:create` and
`policies:coverage` in the ops image against a real database.

New `GET /api/health` is unauthenticated because a probe carries no session,
deliberately uninformative because it's the only route outside the gate, and
deliberately does not touch the database — a liveness probe that fails on a
Postgres blip makes the platform restart a working process.

| | |
|---|---|
| typecheck | 0 errors |
| lint | 0 errors, 3 pre-existing warnings |
| build | clean |
| unit | **118** (was 114) |
| e2e | **54** (was 53) |

## What this deliberately does not set up

Custom domain and certificate; **backup for the Azure Files share holding
student records** (Postgres has the 7-day default, the share has nothing —
worth deciding before the pilot holds anything real); alerting; and rate
limiting, still open from the audit as SEC-11/SEC-23, which matters more once
this has a public hostname.