### PR TITLE
Decide the audit's open questions; close OQ-1 and OQ-3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,16 @@ deadline the policy sets. `Mark done` is their only state change.
 Tokens live in `src/app/theme.css`. There is no `globals.css` — it was deleted,
 and its patterns should not come back.
 
-- **Colour is earned.** It means a deadline state and nothing else: overdue
-  (red), attention (amber), met (green). No brand accent — it would compete with
-  the only signal the UI is allowed to raise its voice with.
+- **Colour is earned.** It means a deadline state — overdue (red), attention
+  (amber), met (green) — or a coverage gap (amber). Nothing else. No brand
+  accent, and never severity, error states or decoration: those would compete
+  with the only signal the UI is allowed to raise its voice with.
+
+  A coverage gap is on this list because it is the same class of signal as a
+  deadline: an actionable compliance warning the administrator has to do
+  something about. It was a documented design decision that this rule
+  contradicted; the rule was widened rather than the components repainted.
+  (OQ-1)
 - **Three fonts, three jobs.** DM Serif Display for titles and answers, DM Sans
   for body and obligation titles, JetBrains Mono with tabular numerals for every
   time, id and count — digits must not jitter as a countdown ticks.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,6 +186,74 @@ Three other things that were true and are no longer:
 
 ---
 
+## Decisions on the audit's open questions — 2026-09-01
+
+The 2026-09-01 audit logged five questions rather than guessing them. All five
+are now decided. Two are done; three are queued below.
+
+**OQ-1 — amber for coverage gaps: allowed. Done.** `CLAUDE.md` said colour meant
+a deadline state and nothing else; `theme.css` and the redesign brief recorded
+amber-for-gaps as deliberate. The rule was widened rather than the components
+repainted: a coverage gap is the same class of signal as a deadline — an
+actionable compliance warning — not decoration. The rule still bites, which is
+why severity chips and error states lost their colour in the audit (SPEC-44).
+
+**OQ-3 — `other` retrieval: the guarantee reading, confirmed. Taxonomy gap
+fixed.** `categoriesForIncidentType` stays empty as a *search filter*;
+`guaranteedCategoriesFor` supplies representation and coverage. Behind that
+sat a worse problem: the taxonomy had no value for abuse or neglect, so *"a
+student told the counsellor her stepfather hits her"* classified as `other` —
+the highest-stakes report this tool handles, on the shortest clock, in the
+bucket that means "we could not tell". `abuse_neglect` is now a first-class
+incident type, mapped narrowly to `mandatory_reporting`, and treated as
+CONFIDENTIAL.
+
+**OQ-5 — deadlines with no policy behind them: keep the obligation, keep the
+urgency, mark the provenance.** *(Queued — this is the B1 fix.)*
+
+Suppressing the obligation is the worst option: "you must report this to DCYF"
+is worth saying even when the library cannot cite a deadline, and *nothing*
+is how a mandated report gets missed. Dropping the countdown loses the urgency,
+which for a 24-hour report is the part that matters. So:
+
+- `ComplianceAction` gains `policyId`, `citation` and `deadlineSource`
+  (`'policy' | 'model'`). It carries none of these today, which is why this is
+  a schema change and not a UI tweak.
+- Two-phase classification: after retrieval, re-derive obligations with
+  `policyContext` — the parameter exists and is passed `undefined` today. A
+  deadline traceable to an excerpt is `policy`; everything else is `model`.
+- **A model-sourced deadline gets no red or amber countdown**, and the home
+  page's "N things are late" counts only policy-backed ones. That headline is
+  currently built on the model's recall of NH law, and it is the number in the
+  product that most looks like fact.
+- `ObligationRow` already renders an `AuthorityChip` and citation whenever they
+  are present. The data has simply never existed.
+
+Also fix `FLOW-35` alongside it: a failed classification should leave
+`incidentType` null so the next turn retries, rather than stamping `other`
+permanently with no way to correct it.
+
+**OQ-2 — canonical ingestion: `/api/admin/policies/upload`.** *(Queued.)*
+Delete `POST /api/policies`; keep `POST /api/admin/policies` for the paste-text
+path the admin UI uses. The deleted route is called by no client, sits outside
+the `/api/admin` prefix so `isAdminPath` does not cover it, and is the route
+SEC-3 exploited. It is documented in README, so this needs a doc change — that
+is the decision, not an obstacle. Standardise the uploads directory on one
+resolution at the same time (DEAD-62): there are four, and one makes
+`policies:reindex` re-copy the source file on every run.
+
+**OQ-4 — the admin-editable system prompt: invert it, but not yet.** *(Queued,
+lowest priority.)* The row replaces the in-code prompt for the chat path only —
+not `classifyIncident`, not `generateChatSummary` — so an admin editing "the
+system prompt" changes one of three calls and silently drops the
+citation-discipline and clarifying-question paragraphs. SEC-20 closed the
+accountability half. The structural fix is to make the row an *appended*
+district-context block with the compliance instructions in code. Until then the
+UI label overstates what it controls; with one admin, that mislabel is the real
+cost.
+
+---
+
 ## Next — gated on real use
 
 ### 6. Run a real incident end to end, and watch it — *maintainer*

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -271,7 +271,11 @@ function determineDataSensitivity(message: string, incident: any): DataSensitivi
     return DataSensitivity.RESTRICTED;
   }
   
-  if (incident.incidentType === 'title_ix' || incident.severity === 'critical') {
+  if (
+    incident.incidentType === 'title_ix' ||
+    incident.incidentType === 'abuse_neglect' ||
+    incident.severity === 'critical'
+  ) {
     return DataSensitivity.CONFIDENTIAL;
   }
   

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -262,6 +262,7 @@ WHAT YOU DO:
 
 2. **Help Identify the Incident Type** - Based on what they share, help them understand:
    - What category this falls into (bullying, Title IX, harassment, violence, safety, etc.)
+   - Use "abuse_neglect" for any disclosure or suspicion of abuse or neglect of a child, including by someone outside the school
    - How serious the situation is
    - Which policies and regulations apply
    - What this means for next steps
@@ -370,7 +371,7 @@ ${NO_POLICY_RETRIEVED_GUARD}`;
 
 Respond with a JSON object containing:
 {
-  "type": "bullying" | "title_ix" | "harassment" | "violence" | "substance" | "other",
+  "type": "bullying" | "title_ix" | "harassment" | "violence" | "substance" | "abuse_neglect" | "other",
   "severity": "low" | "medium" | "high" | "critical",
   "reasoning": "Brief explanation of why this classification was chosen",
   "requiredActions": [

--- a/src/types/incident-categories.test.ts
+++ b/src/types/incident-categories.test.ts
@@ -99,3 +99,24 @@ describe('guaranteedCategoriesFor', () => {
     }
   });
 });
+
+describe('abuse and neglect', () => {
+  // The taxonomy had no value for this, so a disclosure about a child's home
+  // life classified as `other` -- the highest-stakes report this tool handles,
+  // on the shortest clock, in the bucket that means "we could not tell". (OQ-3)
+
+  it('is a first-class incident type', () => {
+    expect(INCIDENT_TYPES).toContain('abuse_neglect');
+  });
+
+  it('retrieves mandatory reporting, and is not diluted with unrelated categories', () => {
+    // Report to whom, by when, is the whole question here.
+    expect(categoriesForIncidentType('abuse_neglect')).toEqual(['mandatory_reporting']);
+  });
+
+  it('constrains the search rather than falling through to no filter', () => {
+    // `other` returns [] which callers treat as "no filter", so a keyword hit
+    // from any unrelated policy could be handed to the model as authority.
+    expect(categoriesForIncidentType('abuse_neglect')).not.toEqual([]);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,17 @@ export const INCIDENT_TYPES = [
   'harassment',
   'violence',
   'substance',
+  /**
+   * Suspected abuse or neglect -- a disclosure about a child's home life, or
+   * an injury a staff member has reason to think was not accidental.
+   *
+   * Added because the taxonomy had no value for it, so "a student told the
+   * counsellor her stepfather hits her" classified as `other`. That is the
+   * highest-stakes report this tool will ever handle, on the shortest clock
+   * (RSA 169-C:29 requires it immediately, not within a window), and it was
+   * the one incident type with no category of its own. (OQ-3)
+   */
+  'abuse_neglect',
   'other',
 ] as const;
 export type IncidentType = (typeof INCIDENT_TYPES)[number];
@@ -31,6 +42,7 @@ export const INCIDENT_TYPE_LABELS: Record<IncidentType, string> = {
   harassment: 'Harassment',
   violence: 'Violence',
   substance: 'Substance',
+  abuse_neglect: 'Abuse / neglect',
   other: 'Other',
 };
 
@@ -193,6 +205,12 @@ const INCIDENT_TYPE_CATEGORIES: Record<IncidentType, PolicyCategory[]> = {
   harassment: ['discrimination', 'title_ix', 'bullying'],
   violence: ['school_safety', 'discipline', 'emergency_operations'],
   substance: ['discipline', 'student_health'],
+  // Deliberately narrow. The governing local policy is the district's
+  // reporting procedure (JLF), and widening this would dilute retrieval for
+  // the one question that matters here: report to whom, by when. With no
+  // mandatory_reporting policy loaded, retrieval returns nothing and the
+  // no-retrieval guard fires -- which is the honest answer, not a failure.
+  abuse_neglect: ['mandatory_reporting'],
   other: [],
 };
 


### PR DESCRIPTION
All five open questions from the 2026-09-01 audit are now decided and recorded
in [`docs/roadmap.md`](docs/roadmap.md). Two are closed here; three are queued
with the reasoning written down rather than left to be re-derived.

## OQ-3 — `other` retrieval, and the gap behind it

The guarantee reading is confirmed (`categoriesForIncidentType` stays empty as
a *filter*, `guaranteedCategoriesFor` supplies representation and coverage).

But behind it sat a worse problem the audit only described in passing: **the
taxonomy had no value for abuse or neglect.** So *"a student told the counsellor
her stepfather hits her"* classified as `other` — the highest-stakes report this
tool will ever handle, on the shortest clock (RSA 169-C:29 requires it
*immediately*, not within a window), landing in the bucket that means "we could
not tell". `other` is also the classifier's failure default, so a genuine abuse
disclosure was indistinguishable from a failed classification.

`abuse_neglect` is now a first-class incident type:

- mapped narrowly to `mandatory_reporting` — report to whom and by when is the
  whole question, and widening it would dilute retrieval
- with no `mandatory_reporting` policy loaded, that filter returns nothing and
  the no-retrieval guard fires, which is the **honest** answer here, not a
  failure
- treated as `CONFIDENTIAL`, alongside `title_ix`

## OQ-1 — amber for coverage gaps

Allowed, and `CLAUDE.md` is the document that was wrong. It said colour meant a
deadline state and nothing else; `theme.css` and the redesign brief both
recorded amber-for-gaps as deliberate. A coverage gap is the same class of
signal as a deadline — an actionable compliance warning — so the rule was
widened rather than three components repainted.

The rule still bites: severity chips and error states lost their colour in the
audit (SPEC-44), and the amended text now names those exclusions explicitly.

## Queued, with the decision attached

- **OQ-5** — keep the obligation, keep the urgency, mark the provenance.
  `ComplianceAction` gains `policyId` / `citation` / `deadlineSource`; two-phase
  classification re-derives after retrieval; **a model-sourced deadline gets no
  red or amber countdown**, and "N things are late" counts only policy-backed
  ones. `ObligationRow` already renders the chip and citation — the data has
  never existed.
- **OQ-2** — `/api/admin/policies/upload` is canonical; delete `POST
  /api/policies` (no client calls it, sits outside the `/api/admin` prefix, and
  is the route SEC-3 exploited).
- **OQ-4** — invert the system prompt to an appended district-context block.
  Lowest priority while there is one admin; the mislabel is the current cost.

| | |
|---|---|
| typecheck | 0 errors |
| lint | 0 errors, 3 pre-existing warnings |
| build | clean |
| unit | **121** (was 118) |
| e2e | 54 |