### PR TITLE
OQ-5: record where each obligation's deadline actually came from

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,16 +293,17 @@ type limits, unvalidated write bodies and pagination, a production container
 running the dev server, and a page that fabricated compliance determinations
 with `Math.random()`.
 
-The 2026-09-01 audit found six blockers. Five are fixed — see
+The 2026-09-01 audit found six blockers. **All six are now fixed** — see
 [`docs/audit/2026-09-01-work-completed.md`](docs/audit/2026-09-01-work-completed.md).
 
-**The sixth is open and you should know it before trusting any deadline this
-tool shows you.** Obligation deadlines are produced by a classification call
-that is never given the retrieved policy, so they are the model's recall of
-New Hampshire law rather than something a policy states, and
-`ComplianceAction` carries no `policyId` to check them against. The fix needs
-a product decision (OQ-5 in the findings). Until it lands, confirm every
-deadline against the cited policy.
+The last of them is worth understanding, because it changes how deadlines
+read. Obligations are now derived **after** retrieval, and each one records
+whether a retrieved policy excerpt actually states its deadline. An obligation
+whose deadline the loaded policy does not support says so on its own row, does
+not get the red or amber of a real deadline state, and is excluded from the
+"N things are late" count. With a thin policy library most obligations will be
+unverified, and that is the honest reading rather than a defect: the system is
+saying it could not find the rule, instead of asserting one.
 
 Still open, and worth knowing before you deploy:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -209,7 +209,7 @@ incident type, mapped narrowly to `mandatory_reporting`, and treated as
 CONFIDENTIAL.
 
 **OQ-5 — deadlines with no policy behind them: keep the obligation, keep the
-urgency, mark the provenance.** *(Queued — this is the B1 fix.)*
+urgency, mark the provenance. Done 2026-09-02.**
 
 Suppressing the obligation is the worst option: "you must report this to DCYF"
 is worth saying even when the library cannot cite a deadline, and *nothing*
@@ -229,9 +229,18 @@ which for a 24-hour report is the part that matters. So:
 - `ObligationRow` already renders an `AuthorityChip` and citation whenever they
   are present. The data has simply never existed.
 
-Also fix `FLOW-35` alongside it: a failed classification should leave
-`incidentType` null so the next turn retries, rather than stamping `other`
-permanently with no way to correct it.
+`FLOW-35` was fixed alongside it: a failed classification now throws rather
+than returning a default, so `incidentType` stays null and the next turn
+retries. The old default (`other` / `low` / no obligations) was written
+permanently, so an API timeout and a genuine "we could not tell" produced the
+same record — on the incident where the system knew least.
+
+What this does **not** do: verify that the deadline the model attributed to an
+excerpt is the deadline that excerpt actually states. It verifies that the
+excerpt exists and was supplied. A model that cites a real excerpt for a number
+that excerpt does not contain still produces a policy-backed row. Closing that
+needs the deadline parsed out of the provision text, which is a bigger piece of
+work and wants real incidents to calibrate against — step 6.
 
 **OQ-2 — canonical ingestion: `/api/admin/policies/upload`.** *(Queued.)*
 Delete `POST /api/policies`; keep `POST /api/admin/policies` for the paste-text

--- a/e2e/incident-management.spec.ts
+++ b/e2e/incident-management.spec.ts
@@ -198,6 +198,67 @@ test.describe('Obligation queue', () => {
     ).toBe(false);
   });
 
+  test('records where each deadline came from, and only counts the backed ones', async ({
+    page,
+  }) => {
+    // The deadline on an obligation used to come from a classification call
+    // that was never shown a policy -- the model's recall of state law -- while
+    // the UI said it came from the policy. Obligations are now derived after
+    // retrieval, and each one records whether a retrieved excerpt actually
+    // states its deadline. (OQ-5)
+    await page.goto('/chat');
+    await page.getByTestId('chat-input').fill(
+      'A student is being bullied repeatedly by a classmate during recess.'
+    );
+    await Promise.all([
+      page.waitForResponse(r => r.url().includes('/api/chat') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: 'Send message' }).click(),
+    ]);
+
+    const { obligations, counts } = await (
+      await page.request.get('/api/obligations?window=all&limit=100')
+    ).json();
+
+    const backed = obligations.filter(
+      (o: { deadlineSource: string }) => o.deadlineSource === 'policy'
+    );
+    const unverified = obligations.filter(
+      (o: { deadlineSource: string }) => o.deadlineSource === 'model'
+    );
+
+    // Both paths must be exercised: a deadline attributed to a retrieved
+    // excerpt, and one the policy does not state.
+    expect(backed.length).toBeGreaterThan(0);
+    expect(unverified.length).toBeGreaterThan(0);
+
+    // A backed obligation carries the provision it rests on; an unverified one
+    // must not, or the citation would be decoration.
+    expect(backed[0].citation).toBeTruthy();
+    expect(typeof backed[0].citation).toBe('string');
+    for (const o of unverified) expect(o.citation).toBeNull();
+
+    // The tallies are assertions of fact about lateness, so they count only
+    // deadlines a policy supports.
+    expect(counts.unverified).toBe(
+      obligations.filter(
+        (o: { deadlineSource: string; status: string }) =>
+          o.deadlineSource === 'model' && o.status !== 'completed'
+      ).length
+    );
+    expect(counts.open).toBeGreaterThanOrEqual(counts.unverified);
+  });
+
+  test('tells the administrator when a deadline is not backed by loaded policy', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    // The row says so itself: a countdown with no policy behind it must not
+    // read as a statutory clock.
+    await expect(
+      page.getByText('Deadline not found in the loaded policy').first()
+    ).toBeVisible();
+  });
+
   test('shows the empty state when nothing is outstanding', async ({ page }) => {
     // Production sits in exactly this state after clearing test data, and
     // nothing covered it: the queue rendered from a non-empty fixture every

--- a/e2e/support/claude-stub.ts
+++ b/e2e/support/claude-stub.ts
@@ -58,6 +58,24 @@ function replyFor(body: StubRequest): string {
   if (system.includes('concise, descriptive titles for school incident reports')) {
     return 'Playground Bullying Report';
   }
+  // Obligation derivation. Attribute the first obligation to excerpt [1] when
+  // the prompt actually contains one, and leave the second unattributed, so the
+  // suite exercises both the policy-backed and the unverified path. The excerpt
+  // number is only honoured if the route can resolve it, which is the point.
+  if (system.includes('list the actions the administrator must take')) {
+    const hasExcerpt = /\[1\]/.test(userText);
+    return JSON.stringify({
+      obligations: [
+        {
+          description: 'Notify the superintendent',
+          dueInHours: 24,
+          sourceExcerpt: hasExcerpt ? 1 : null,
+        },
+        { description: 'Complete the investigation report', dueInHours: 240, sourceExcerpt: null },
+      ],
+    });
+  }
+
   if (system.includes('school district attorney reviewing an incident consultation')) {
     return 'SUMMARY: consultation summary for the incident file.';
   }

--- a/prisma/migrations/20260902090000_add_obligation_provenance/migration.sql
+++ b/prisma/migrations/20260902090000_add_obligation_provenance/migration.sql
@@ -1,0 +1,24 @@
+-- Deadline provenance on an obligation.
+--
+-- The deadline on a ComplianceAction is produced by a classification call that
+-- was never shown a policy, so it is the model's recall of state law rather
+-- than something a retrieved policy states -- while the UI told the
+-- administrator it came from the policy. The row could not represent the
+-- difference, which is why this is a schema change and not a UI fix. (OQ-5)
+--
+-- Nullable and defaulted so existing rows are valid: every obligation created
+-- before this migration was produced without policy context, and 'model' is
+-- the truthful description of all of them.
+
+ALTER TABLE "public"."ComplianceAction" ADD COLUMN "deadlineSource" TEXT NOT NULL DEFAULT 'model';
+ALTER TABLE "public"."ComplianceAction" ADD COLUMN "citation" TEXT;
+ALTER TABLE "public"."ComplianceAction" ADD COLUMN "policyId" TEXT;
+
+-- SetNull: deleting a policy must not delete obligations an administrator is
+-- still accountable for. They lose the citation and fall back to unverified.
+ALTER TABLE "public"."ComplianceAction"
+  ADD CONSTRAINT "ComplianceAction_policyId_fkey"
+  FOREIGN KEY ("policyId") REFERENCES "public"."Policy"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "ComplianceAction_policyId_idx" ON "public"."ComplianceAction"("policyId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,10 +16,10 @@ datasource db {
 // ============================================
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String
-  role      String   @default("reporter") // admin, investigator, reporter
+  id    String @id @default(cuid())
+  email String @unique
+  name  String
+  role  String @default("reporter") // admin, investigator, reporter
 
   // Authentication. Credentials provider with JWT sessions, so no Account /
   // Session / VerificationToken models are needed. Nullable because rows
@@ -34,11 +34,11 @@ model User {
   updatedAt DateTime @updatedAt
 
   // Relations
-  reportedIncidents  Incident[]         @relation("IncidentReporter")
-  assignedActions    ComplianceAction[] @relation("AssignedActions")
-  conversations      Conversation[]
-  attachments        Attachment[]
-  auditLogs          AuditLog[]
+  reportedIncidents Incident[]         @relation("IncidentReporter")
+  assignedActions   ComplianceAction[] @relation("AssignedActions")
+  conversations     Conversation[]
+  attachments       Attachment[]
+  auditLogs         AuditLog[]
 
   @@index([email])
   @@index([role])
@@ -49,14 +49,14 @@ model User {
 // ============================================
 
 model Incident {
-  id          String   @id @default(cuid())
+  id          String @id @default(cuid())
   title       String
   description String
 
   // Classification
-  incidentType String?  // bullying, title_ix, harassment, violence, other
-  severity     String?  // low, medium, high, critical
-  status       String   @default("open") // open, in_progress, under_review, completed, closed
+  incidentType String? // bullying, title_ix, harassment, violence, other
+  severity     String? // low, medium, high, critical
+  status       String  @default("open") // open, in_progress, under_review, completed, closed
 
   // Reporter information
   reporterId String
@@ -67,15 +67,15 @@ model Incident {
   metadata String? // JSON: Additional metadata, classification details, stakeholders
 
   // Timestamps
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   closedAt  DateTime?
 
   // Relations
-  conversations      Conversation[]
-  complianceActions  ComplianceAction[]
-  attachments        Attachment[]
-  auditLogs          AuditLog[]
+  conversations     Conversation[]
+  complianceActions ComplianceAction[]
+  attachments       Attachment[]
+  auditLogs         AuditLog[]
 
   @@index([reporterId])
   @@index([status])
@@ -93,8 +93,8 @@ model Conversation {
   incidentId String
   incident   Incident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
 
-  message  String
-  sender   String  // user, assistant
+  message String
+  sender  String // user, assistant
 
   // User reference (optional, for tracking who sent user messages)
   userId String?
@@ -115,22 +115,41 @@ model Conversation {
 // ============================================
 
 model ComplianceAction {
-  id          String   @id @default(cuid())
-  incidentId  String
-  incident    Incident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
+  id         String   @id @default(cuid())
+  incidentId String
+  incident   Incident @relation(fields: [incidentId], references: [id], onDelete: Cascade)
 
-  actionType  String   // Type of action required
+  actionType  String // Type of action required
   description String?
-  status      String   @default("pending") // pending, in_progress, completed, overdue
+  status      String  @default("pending") // pending, in_progress, completed, overdue
 
   // Assignment and timing
   assignedTo   String?
-  assignedUser User?    @relation("AssignedActions", fields: [assignedTo], references: [id])
+  assignedUser User?     @relation("AssignedActions", fields: [assignedTo], references: [id])
   dueDate      DateTime?
   completedAt  DateTime?
 
   // Evidence files (JSON array of file paths)
   evidenceFiles String?
+
+  /// Which policy excerpt this obligation's deadline was actually drawn from,
+  /// and how it was reached.
+  ///
+  /// `deadlineSource` is 'policy' when the model attributed the deadline to a
+  /// retrieved excerpt AND that attribution resolved to a real reference, and
+  /// 'model' otherwise. It is not a confidence score: it is the difference
+  /// between a deadline the district's own policy states and one recalled from
+  /// training. A confidently wrong statutory deadline is worse than no answer,
+  /// so the two must be distinguishable at the row level rather than inferred
+  /// from the text. (OQ-5)
+  ///
+  /// SetNull, not Cascade: deleting a policy must not delete the obligations
+  /// an administrator is still on the hook for. They lose their citation and
+  /// fall back to unverified, which is the honest degradation.
+  deadlineSource String  @default("model")
+  citation       String?
+  policyId       String?
+  policy         Policy? @relation(fields: [policyId], references: [id], onDelete: SetNull)
 
   // Timestamps
   createdAt DateTime @default(now())
@@ -147,10 +166,10 @@ model ComplianceAction {
 // ============================================
 
 model Policy {
-  id            String   @id @default(cuid())
-  title         String
-  content       String?  // Full policy text
-  filePath      String?  // Path to uploaded file
+  id       String  @id @default(cuid())
+  title    String
+  content  String? // Full policy text
+  filePath String? // Path to uploaded file
 
   version       Int      @default(1)
   effectiveDate DateTime
@@ -159,13 +178,13 @@ model Policy {
   /// Orthogonal to `category` -- a district bullying policy and a federal
   /// Title IX rule are different jurisdictions AND different categories, and
   /// an incident normally implicates several of both.
-  jurisdiction  String   @default("district")
+  jurisdiction String @default("district")
 
   /// What the policy is about: bullying, title_ix, mandatory_reporting, ...
   /// This is what incident classification matches against during retrieval.
-  category      String   @default("other")
+  category String @default("other")
 
-  isActive      Boolean  @default(true)
+  isActive Boolean @default(true)
 
   // Metadata (JSON: keywords, categories, etc.)
   metadata String?
@@ -175,7 +194,9 @@ model Policy {
   updatedAt DateTime @updatedAt
 
   // Relations
-  chunks PolicyChunk[]
+  chunks            PolicyChunk[]
+  /// Obligations whose deadline was attributed to this policy. (OQ-5)
+  complianceActions ComplianceAction[]
 
   @@index([jurisdiction])
   @@index([category])
@@ -186,12 +207,12 @@ model Policy {
 }
 
 model PolicyChunk {
-  id         String   @id @default(cuid())
-  policyId   String
-  policy     Policy   @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  id       String @id @default(cuid())
+  policyId String
+  policy   Policy @relation(fields: [policyId], references: [id], onDelete: Cascade)
 
-  content    String   // Chunk text content
-  chunkIndex Int      // Order within the policy
+  content    String // Chunk text content
+  chunkIndex Int // Order within the policy
 
   /// The document's own section label for this chunk, e.g. "F". Null when the
   /// policy has no parseable structure, in which case it is cited at policy
@@ -221,20 +242,20 @@ model PolicyChunk {
 // ============================================
 
 model Attachment {
-  id         String   @id @default(cuid())
+  id String @id @default(cuid())
 
   // File information
-  filename   String
-  filePath   String
-  fileType   String
-  fileSize   Int
+  filename String
+  filePath String
+  fileType String
+  fileSize Int
 
   // Relations
   incidentId String?
   incident   Incident? @relation(fields: [incidentId], references: [id], onDelete: Cascade)
 
   uploadedBy String
-  uploader   User     @relation(fields: [uploadedBy], references: [id])
+  uploader   User   @relation(fields: [uploadedBy], references: [id])
 
   // Timestamps
   createdAt DateTime @default(now())
@@ -248,19 +269,19 @@ model Attachment {
 // ============================================
 
 model AuditLog {
-  id        String   @id @default(cuid())
+  id String @id @default(cuid())
 
   // What happened
-  action    String   // created, updated, deleted, viewed, exported
-  entity    String   // incident, policy, user, etc.
-  entityId  String?  // ID of the affected entity
+  action   String // created, updated, deleted, viewed, exported
+  entity   String // incident, policy, user, etc.
+  entityId String? // ID of the affected entity
 
   // Who did it
-  userId    String
-  user      User     @relation(fields: [userId], references: [id])
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
 
   // Details (JSON: before/after values, IP address, etc.)
-  details   String?
+  details String?
 
   // When
   timestamp DateTime @default(now())
@@ -280,14 +301,14 @@ model AuditLog {
 // ============================================
 
 model SystemPrompt {
-  id        String   @id @default(cuid())
-  name      String   // Friendly name like "Friendly Advisor", "Strict Legal", etc.
-  content   String   // The full system prompt text
-  isActive  Boolean  @default(false)
+  id       String  @id @default(cuid())
+  name     String // Friendly name like "Friendly Advisor", "Strict Legal", etc.
+  content  String // The full system prompt text
+  isActive Boolean @default(false)
 
   // Metadata
   description String?
-  createdBy   String?  // User ID who created it
+  createdBy   String? // User ID who created it
 
   // Timestamps
   createdAt DateTime @default(now())

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ragSystem } from '@/lib/ai/rag';
 import { incidentClassifier } from '@/lib/ai/classifier';
-import { DataSensitivity, INCIDENT_TYPE_LABELS } from '@/types';
+import { DataSensitivity, INCIDENT_TYPE_LABELS, PolicyReference } from '@/types';
 import { logRequest, logResponse, logError } from '@/lib/logger';
 import { recordAudit } from '@/lib/audit';
 import { createErrorResponse, validationError, notFoundError } from '@/lib/errors';
@@ -10,6 +10,9 @@ import { chatMessageSchema, validateRequest, formatValidationErrors } from '@/li
 import { LLMUnavailableError } from '@/lib/ai/llm-service';
 import { SUMMARY_SENDER } from '@/lib/ai/incident-summary';
 import { incidentScope, requireUser } from '@/lib/session';
+import { actionTypeFor, ClassificationUnavailableError } from '@/lib/ai/classifier';
+import { resolveProvenance } from '@/lib/obligation-provenance';
+import { claudeService } from '@/lib/ai/claude-service';
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
@@ -128,48 +131,48 @@ export async function POST(request: NextRequest) {
     // incidentType, severity, timeline null and zero ComplianceAction rows.
     // (FLOW-18, SPEC-10)
     if (!incident.incidentType) {
-      classification = await incidentClassifier.classifyIncident(
-        message,
-        {
+      try {
+        classification = await incidentClassifier.classifyIncident(message, {
           incidentId: incident.id,
           reporterId: userId,
-        }
-      );
+        });
 
-      const typeLabel = INCIDENT_TYPE_LABELS[classification.type] || 'Incident';
+        const typeLabel = INCIDENT_TYPE_LABELS[classification.type] || 'Incident';
 
-      // Enhance title with incident type
-      const enhancedTitle = incident.title.startsWith(typeLabel)
-        ? incident.title
-        : `${typeLabel}: ${incident.title}`;
+        // Enhance title with incident type
+        const enhancedTitle = incident.title.startsWith(typeLabel)
+          ? incident.title
+          : `${typeLabel}: ${incident.title}`;
 
-      // Update incident with classification and enhanced title
-      await prisma.incident.update({
-        where: { id: incident.id },
-        data: {
-          title: enhancedTitle,
-          incidentType: classification.type,
-          severity: classification.severity,
-          timeline: JSON.stringify(classification.timeline),
-          metadata: JSON.stringify({
-            classification,
-            stakeholders: classification.stakeholders,
-          }),
-        },
-      });
-
-      // Create compliance actions
-      for (const action of classification.requiredActions) {
-        await prisma.complianceAction.create({
+        // Update incident with classification and enhanced title
+        await prisma.incident.update({
+          where: { id: incident.id },
           data: {
-            incidentId: incident.id,
-            actionType: action.type,
-            description: action.description,
-            dueDate: action.dueDate,
-            assignedTo: action.assignedTo,
-            status: 'pending',
+            title: enhancedTitle,
+            incidentType: classification.type,
+            severity: classification.severity,
+            timeline: JSON.stringify(classification.timeline),
+            metadata: JSON.stringify({
+              classification,
+              stakeholders: classification.stakeholders,
+            }),
           },
         });
+
+        // Obligations are NOT created here. Classification runs before
+        // retrieval -- its categories are what retrieval filters on -- so at
+        // this point no policy has been consulted and any deadline would be
+        // the model's recall of state law. They are created after retrieval,
+        // below. (OQ-5)
+      } catch (error) {
+        if (!(error instanceof ClassificationUnavailableError)) throw error;
+        // Leave incidentType null so the next turn retries. The guidance call
+        // below still runs -- an administrator mid-incident should get an
+        // answer -- it is just retrieved without a category filter, and the
+        // incident stays visibly unclassified rather than being stamped
+        // `other` forever. (FLOW-35)
+        logError(error, { endpoint: '/api/chat', note: 'classification unavailable; will retry next turn' });
+        classification = null;
       }
     }
 
@@ -178,7 +181,12 @@ export async function POST(request: NextRequest) {
     // null and the category filter matched nothing -- on the one turn that
     // matters most. Diagnosing the incident is what tells us which policies
     // apply, which is the whole point of the tool.
-    const { response: policyContext, citations, coverage } = await ragSystem.generateResponseWithCitations(
+    const {
+      response: policyContext,
+      citations,
+      coverage,
+      references,
+    } = await ragSystem.generateResponseWithCitations(
       message,
       {
         incidentId: incident.id,
@@ -187,6 +195,12 @@ export async function POST(request: NextRequest) {
         previousMessages: priorMessages,
       }
     );
+
+    // Phase two: now that policy has been retrieved, derive the obligations
+    // from it and record where each deadline actually came from. (OQ-5)
+    if (classification) {
+      await createObligations(incident.id, message, policyContext, references, classification);
+    }
 
     const { content: response, usage } = await (await import('@/lib/ai/llm-service')).llmService.generateSchoolComplianceResponse(
       message,
@@ -252,6 +266,67 @@ export async function POST(request: NextRequest) {
 
     logResponse('POST', '/api/chat', errorResponse.status, duration);
     return errorResponse;
+  }
+}
+
+/**
+ * Create an incident's obligations from the policy that was actually retrieved.
+ *
+ * Two passes, because the ordering is forced: classification produces the
+ * categories retrieval filters on, so it cannot see policy, and its deadlines
+ * are therefore the model's recall of state law. This pass re-derives them with
+ * the excerpts in hand and records, per obligation, whether the deadline came
+ * from a retrieved policy or from the model.
+ *
+ * The model's attribution is checked, not trusted. `sourceExcerpt` is resolved
+ * against the excerpts actually supplied; a number that does not resolve --
+ * invented, or off-by-one -- yields an unverified obligation rather than a
+ * confident citation to the wrong provision.
+ *
+ * Falls back to the first-pass obligations when the second pass returns
+ * nothing (an empty library, or an unparseable response). Those are recorded
+ * as model-sourced, which is exactly what they are: losing the obligation
+ * entirely would be worse, because "you must report this to DCYF" is worth
+ * saying even when no deadline can be attributed. (OQ-5)
+ */
+async function createObligations(
+  incidentId: string,
+  message: string,
+  policyContext: string,
+  references: PolicyReference[],
+  classification: { requiredActions: { type: string; description: string; dueDate: Date }[] }
+): Promise<void> {
+  const { obligations } = await claudeService.deriveObligations(message, policyContext);
+
+  if (obligations.length > 0) {
+    for (const obligation of obligations) {
+      const provenance = resolveProvenance(obligation.sourceExcerpt, references);
+
+      await prisma.complianceAction.create({
+        data: {
+          incidentId,
+          actionType: actionTypeFor(obligation.description),
+          description: obligation.description,
+          dueDate: new Date(Date.now() + obligation.dueInHours * 60 * 60 * 1000),
+          status: 'pending',
+          ...provenance,
+        },
+      });
+    }
+    return;
+  }
+
+  for (const action of classification.requiredActions) {
+    await prisma.complianceAction.create({
+      data: {
+        incidentId,
+        actionType: action.type,
+        description: action.description,
+        dueDate: action.dueDate,
+        status: 'pending',
+        deadlineSource: 'model',
+      },
+    });
   }
 }
 

--- a/src/app/api/obligations/route.ts
+++ b/src/app/api/obligations/route.ts
@@ -49,6 +49,8 @@ export async function GET(request: NextRequest) {
       incidentId: action.incidentId,
       incidentTitle: action.incident.title,
       incidentType: action.incident.incidentType,
+      deadlineSource: action.deadlineSource,
+      citation: action.citation,
     }));
 
     const now = Date.now();
@@ -58,23 +60,32 @@ export async function GET(request: NextRequest) {
     endOfWeek.setDate(endOfWeek.getDate() + 7);
 
     const open = obligations.filter(o => o.status !== 'completed');
+    // Only policy-backed deadlines are counted. The headline these feed --
+    // "N things are late" -- is the number in the product that most looks like
+    // fact, and counting a deadline the model recalled rather than a policy
+    // stated would make it a confident assertion about a guess. Unverified
+    // obligations are still listed, and still say they need confirming; they
+    // just do not raise an alarm the system cannot substantiate. (OQ-5)
+    const backed = open.filter(o => o.deadlineSource === 'policy');
     const due = (o: (typeof obligations)[number]) =>
       o.dueDate ? new Date(o.dueDate).getTime() : null;
 
     return NextResponse.json({
       obligations,
       counts: {
-        overdue: open.filter(o => due(o) !== null && due(o)! < now).length,
-        today: open.filter(
+        overdue: backed.filter(o => due(o) !== null && due(o)! < now).length,
+        today: backed.filter(
           o => due(o) !== null && due(o)! >= now && due(o)! <= endOfToday.getTime()
         ).length,
-        week: open.filter(
+        week: backed.filter(
           o =>
             due(o) !== null &&
             due(o)! > endOfToday.getTime() &&
             due(o)! <= endOfWeek.getTime()
         ).length,
         open: open.length,
+        /** Open obligations whose deadline no retrieved policy supports. */
+        unverified: open.length - backed.length,
       },
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,8 +64,15 @@ export default function HomePage() {
   const due = (o: Obligation) => (o.dueDate ? new Date(o.dueDate).getTime() : null);
   const open = obligations.filter(o => o.status !== 'completed');
 
-  const overdue = open.filter(o => due(o) !== null && due(o)! < now);
-  const today = open.filter(
+  // The headline states a fact about lateness, so it counts only deadlines a
+  // retrieved policy actually supports -- the same rule /api/obligations
+  // applies to its tallies. Counting an unverified deadline here would put a
+  // guess in the largest text on the page. Those obligations are still listed
+  // below, and say on their own row that they need confirming. (OQ-5)
+  const verified = open.filter(o => o.deadlineSource !== 'model');
+
+  const overdue = verified.filter(o => due(o) !== null && due(o)! < now);
+  const today = verified.filter(
     o => due(o) !== null && due(o)! >= now && due(o)! <= endOfToday.getTime()
   );
   const later = open.filter(o => due(o) === null || due(o)! > endOfToday.getTime());
@@ -78,12 +85,20 @@ export default function HomePage() {
         ? `Nothing is late.`
         : `You're clear.`;
 
+  const unverified = open.length - verified.length;
+  const unverifiedNote =
+    unverified > 0
+      ? ` ${unverified === 1 ? 'One obligation has' : `${unverified} obligations have`} a deadline no loaded policy states.`
+      : '';
+
   const subhead =
-    today.length > 0
+    (today.length > 0
       ? `${today.length === 1 ? 'One more is' : `${today.length} more are`} due today.`
       : overdue.length > 0
         ? 'Nothing else is due today.'
-        : 'No obligations are outstanding.';
+        : open.length > 0
+          ? 'Nothing with a confirmed deadline is outstanding.'
+          : 'No obligations are outstanding.') + unverifiedNote;
 
   const stamp = new Date().toLocaleString('en-US', {
     weekday: 'long',

--- a/src/components/design/DeadlineClock.tsx
+++ b/src/components/design/DeadlineClock.tsx
@@ -14,20 +14,33 @@ export function DeadlineClock({
   dueDate,
   status,
   completedAt,
+  /**
+   * False when no retrieved policy supports this deadline.
+   *
+   * Such a deadline still shows -- an obligation without its urgency is close
+   * to useless, and "report to DCYF" matters whether or not a deadline could be
+   * attributed -- but it does not get red or amber. Colour in this UI means a
+   * deadline state, and a deadline the system cannot substantiate has not
+   * earned the one signal the interface is allowed to raise its voice with.
+   * (OQ-5)
+   */
+  verified = true,
   className = '',
 }: {
   dueDate: string | Date | null | undefined;
   status: string;
   completedAt?: string | Date | null;
+  verified?: boolean;
   className?: string;
 }) {
   const mounted = useMounted();
   const { state, label, absolute } = describeDeadline(dueDate, status, completedAt);
+  const tone = verified || state === 'met' ? DEADLINE_COLOR[state] : 'text-text-tertiary';
 
   return (
     <div className={`flex w-[120px] flex-none flex-col gap-[3px] ${className}`}>
       {/* Reserve the line height so nothing shifts when the client fills it in. */}
-      <span className={`tabular text-[15px] font-medium leading-none ${DEADLINE_COLOR[state]}`}>
+      <span className={`tabular text-[15px] font-medium leading-none ${tone}`}>
         {mounted ? label : '\u00a0'}
       </span>
       {mounted && absolute && (

--- a/src/components/design/ObligationRow.tsx
+++ b/src/components/design/ObligationRow.tsx
@@ -15,6 +15,8 @@ export interface Obligation {
   incidentTitle?: string;
   jurisdiction?: string;
   citation?: string;
+  /** 'policy' when a retrieved excerpt states this deadline, else 'model'. */
+  deadlineSource?: string;
 }
 
 /**
@@ -53,6 +55,7 @@ export function ObligationRow({
         dueDate={obligation.dueDate}
         status={obligation.status}
         completedAt={obligation.completedAt}
+        verified={obligation.deadlineSource !== 'model'}
       />
 
       <div className="flex flex-1 flex-col gap-1.5">
@@ -66,6 +69,12 @@ export function ObligationRow({
 
         {obligation.incidentTitle && showIncident && (
           <span className="text-[12px] text-text-muted">{obligation.incidentTitle}</span>
+        )}
+
+        {obligation.deadlineSource === 'model' && !done && (
+          <span className="text-[12px] leading-[1.4] text-text-muted">
+            Deadline not found in the loaded policy — confirm it before acting.
+          </span>
         )}
 
         {(obligation.jurisdiction || obligation.citation) && (

--- a/src/lib/ai/classifier.ts
+++ b/src/lib/ai/classifier.ts
@@ -1,6 +1,35 @@
 import { IncidentClassification, Action, ComplianceTimeline } from '@/types';
 import { claudeService } from './claude-service';
 
+/**
+ * Bucket an obligation by what it asks the administrator to do.
+ *
+ * Exported because obligations are now created in two places -- the two-phase
+ * path in the chat route, and this classifier's fallback -- and the same
+ * description must bucket the same way in both. Duplicating it is how the two
+ * summary endpoints drifted apart. (OQ-5)
+ */
+/**
+ * Classification could not be completed -- distinct from classifying as
+ * `other`, which is a real answer. (FLOW-35)
+ */
+export class ClassificationUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClassificationUnavailableError';
+  }
+}
+
+export function actionTypeFor(description: string): string {
+  const lower = description.toLowerCase();
+  if (lower.includes('immediate') || lower.includes('urgent')) return 'immediate_response';
+  if (lower.includes('investigate')) return 'investigation';
+  if (lower.includes('notify') || lower.includes('contact')) return 'notification';
+  if (lower.includes('document')) return 'documentation';
+  if (lower.includes('report')) return 'reporting';
+  return 'general_action';
+}
+
 export class IncidentClassifier {
   async classifyIncident(
     description: string,
@@ -24,7 +53,7 @@ export class IncidentClassifier {
       const requiredActions: Action[] = classification.requiredActions.map(
         (action, idx) => ({
           id: `action_${idx + 1}`,
-          type: this.determineActionType(action.description),
+          type: actionTypeFor(action.description),
           description: action.description,
           dueDate: new Date(Date.now() + action.dueInHours * 60 * 60 * 1000),
           status: 'pending' as const,
@@ -41,25 +70,19 @@ export class IncidentClassifier {
         stakeholders: classification.stakeholders,
       };
     } catch (error) {
-      console.error('Classification error:', error);
-      // Return default classification on error
-      return this.getDefaultClassification();
+      // Let the failure surface. It used to return a default of
+      // `type: 'other', severity: 'low', requiredActions: []`, which the route
+      // then wrote to the incident -- and because the route only classifies
+      // when incidentType is null, that stamp was permanent, with no endpoint
+      // to correct it. A timed-out API call and a genuine "we could not tell"
+      // became the same record, on the incident where the system knew least.
+      //
+      // Throwing leaves incidentType null so the next turn tries again. The
+      // caller decides what to show meanwhile. (FLOW-35)
+      throw new ClassificationUnavailableError(
+        error instanceof Error ? error.message : 'Classification failed'
+      );
     }
-  }
-
-  /**
-   * Determine action type from description
-   */
-  private determineActionType(description: string): string {
-    const lower = description.toLowerCase();
-    if (lower.includes('immediate') || lower.includes('urgent'))
-      return 'immediate_response';
-    if (lower.includes('investigate')) return 'investigation';
-    if (lower.includes('notify') || lower.includes('contact'))
-      return 'notification';
-    if (lower.includes('document')) return 'documentation';
-    if (lower.includes('report')) return 'reporting';
-    return 'general_action';
   }
 
   /**
@@ -96,21 +119,13 @@ export class IncidentClassifier {
     };
   }
 
-  private getDefaultClassification(): IncidentClassification {
-    return {
-      type: 'other',
-      severity: 'low',
-      requiredActions: [],
-      timeline: {
-        immediateActions: [],
-        shortTermActions: [],
-        investigationPhase: [],
-        reportingDeadlines: [],
-        reviewMilestones: [],
-      },
-      stakeholders: [],
-    };
-  }
+  // getDefaultClassification is gone. It returned `type: 'other', severity:
+  // 'low', requiredActions: []` on any failure, which the route wrote to the
+  // incident permanently -- so an API timeout became an incident classified as
+  // "we could not tell" with zero obligations and no way to correct it.
+  // Failure now throws; see the catch above. Kept out rather than left unused,
+  // because a plausible-looking safe default is exactly what someone would
+  // re-wire. (FLOW-35)
 }
 
 export const incidentClassifier = new IncidentClassifier();

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -11,6 +11,24 @@ import { INCIDENT_TYPES, PolicyCoverage, SEVERITIES } from '@/types';
  * `type: string` and cast with `as any` at the call site, so a malformed or
  * injected value flowed straight into the incident record. (SEC-9, DEAD-13)
  */
+const derivedObligationsSchema = z.object({
+  obligations: z.array(
+    z.object({
+      description: z.string().min(1),
+      dueInHours: z.number().positive().max(24 * 365),
+      // null is a first-class answer here, and the common one while the policy
+      // library is thin. Coercing it to a number would be the whole bug.
+      sourceExcerpt: z.number().int().positive().nullable(),
+    })
+  ),
+});
+
+export interface DerivedObligation {
+  description: string;
+  dueInHours: number;
+  sourceExcerpt: number | null;
+}
+
 const classificationSchema = z.object({
   type: z.enum(INCIDENT_TYPES),
   severity: z.enum(SEVERITIES),
@@ -489,6 +507,69 @@ Example: ["Question 1?", "Question 2?", "Question 3?"]`;
   /**
    * Generate end-of-chat summary with policy citations and next steps
    */
+  /**
+   * Re-derive an incident's obligations with the retrieved policy in front of
+   * the model, and make it say which excerpt each deadline came from.
+   *
+   * Classification has to run before retrieval -- the categories it produces
+   * are what retrieval filters on -- so at classification time there is no
+   * policy to consult, and the deadlines it produced were the model's recall
+   * of state law. This is the second pass that closes the loop.
+   *
+   * The attribution is a claim, not a fact: `sourceExcerpt` is resolved
+   * against the excerpts actually supplied, and one that does not resolve is
+   * recorded as model-sourced. (OQ-5)
+   */
+  async deriveObligations(
+    description: string,
+    policyContext: string
+  ): Promise<{ obligations: DerivedObligation[]; usage: ClaudeResponse['usage'] }> {
+    if (!policyContext.trim()) {
+      return { obligations: [], usage: { inputTokens: 0, outputTokens: 0 } };
+    }
+
+    const systemPrompt = `You are a school district compliance attorney. Given an incident and the policy excerpts retrieved for it, list the actions the administrator must take.
+
+Each excerpt is numbered, like "[2] JICK §D — Procedures for Reporting (RSA 193-F:4, II(f) - (h))".
+
+For every action, you MUST decide where its deadline comes from:
+- If a supplied excerpt states the deadline, set "sourceExcerpt" to that excerpt's number.
+- If no supplied excerpt states it, set "sourceExcerpt" to null. Do NOT guess a number, and do NOT cite an excerpt that does not actually state the deadline. An action with a null source is still worth listing — it will be shown to the administrator as unverified, which is accurate and useful. Attributing it to an excerpt that does not support it is not.
+
+Return ONLY valid JSON:
+{
+  "obligations": [
+    { "description": "...", "dueInHours": 24, "sourceExcerpt": 2 },
+    { "description": "...", "dueInHours": 72, "sourceExcerpt": null }
+  ]
+}`;
+
+    const request = `INCIDENT:
+${description}
+
+RETRIEVED POLICY EXCERPTS:
+${policyContext}`;
+
+    const response = await this.generateResponse(
+      [{ role: 'user', content: request }],
+      systemPrompt,
+      { temperature: 0.2, maxTokens: 1500 }
+    );
+
+    try {
+      const parsed = derivedObligationsSchema.parse(
+        JSON.parse(extractJsonObject(response.content))
+      );
+      return { obligations: parsed.obligations, usage: response.usage };
+    } catch (error) {
+      // A parse failure must not invent obligations. Returning none leaves the
+      // first-pass ones in place, recorded as model-sourced, which is what they
+      // are.
+      console.error('deriveObligations: could not parse response', error);
+      return { obligations: [], usage: response.usage };
+    }
+  }
+
   async generateChatSummary(
     conversationHistory: ClaudeMessage[],
     policyContext: string,

--- a/src/lib/ai/rag.ts
+++ b/src/lib/ai/rag.ts
@@ -6,6 +6,7 @@ import {
   POLICY_JURISDICTIONS,
   PolicyChunk,
   PolicyCitation,
+  PolicyReference,
   PolicyCoverage,
   LOCAL_JURISDICTIONS,
 } from '@/types';
@@ -299,6 +300,7 @@ export class RAGSystem {
     citations: PolicyCitation[];
     chunks: PolicyChunk[];
     coverage: PolicyCoverage;
+    references: PolicyReference[];
   }> {
     // Retrieval query includes the incident type and the last couple of user
     // turns. Previously the context argument was named `_context` and never
@@ -330,7 +332,8 @@ export class RAGSystem {
 
     const relevantChunks = await this.ensureCategoryRepresentation(matched, guaranteed);
 
-    const policyContext = this.buildJurisdictionContext(relevantChunks);
+    const references: PolicyReference[] = [];
+    const policyContext = this.buildJurisdictionContext(relevantChunks, references);
     const citations = this.buildCitations(relevantChunks);
     const coverage = await this.assessCoverage(guaranteed);
 
@@ -339,6 +342,7 @@ export class RAGSystem {
       citations,
       chunks: relevantChunks,
       coverage,
+      references,
     };
   }
 
@@ -407,7 +411,13 @@ export class RAGSystem {
    * from a school handbook -- and the citations it was asked to produce were
    * raw cuids nobody could look up.
    */
-  private buildJurisdictionContext(chunks: PolicyChunk[]): string {
+  private buildJurisdictionContext(
+    chunks: PolicyChunk[],
+    // Populated as the excerpts are numbered, so an attribution the model
+    // makes can be checked against the excerpts it was actually given rather
+    // than taken on trust. (OQ-5)
+    references?: PolicyReference[]
+  ): string {
     if (chunks.length === 0) return '';
 
     const sections: string[] = [];
@@ -428,6 +438,7 @@ export class RAGSystem {
               statute: chunk.sectionStatute ?? undefined,
             })
           : title;
+        references?.push({ n, policyId: chunk.policyId, citation: source });
         return `[${n}] ${source}\n${chunk.content}`;
       });
 

--- a/src/lib/obligation-provenance.test.ts
+++ b/src/lib/obligation-provenance.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProvenance } from './obligation-provenance';
+import type { PolicyReference } from '@/types';
+
+/**
+ * The whole point of OQ-5: an obligation may only claim a policy backs its
+ * deadline when the excerpt it names was actually supplied. Everything here is
+ * a way the model can be wrong about its own reasoning.
+ */
+const REFERENCES: PolicyReference[] = [
+  { n: 1, policyId: 'p-jick', citation: 'JICK §D — Procedures for Reporting (RSA 193-F:4)' },
+  { n: 2, policyId: 'p-jlf', citation: 'JLF — Reporting Child Abuse and Neglect' },
+];
+
+describe('resolveProvenance', () => {
+  it('accepts an attribution that resolves to a supplied excerpt', () => {
+    expect(resolveProvenance(1, REFERENCES)).toEqual({
+      deadlineSource: 'policy',
+      policyId: 'p-jick',
+      citation: 'JICK §D — Procedures for Reporting (RSA 193-F:4)',
+    });
+  });
+
+  it('carries the citation of the excerpt named, not of the first one', () => {
+    expect(resolveProvenance(2, REFERENCES).citation).toBe(
+      'JLF — Reporting Child Abuse and Neglect'
+    );
+  });
+
+  it('treats an unattributed deadline as unverified rather than dropping it', () => {
+    // null is the honest and, with a thin library, the common answer. The
+    // obligation still exists; it just does not claim policy support.
+    expect(resolveProvenance(null, REFERENCES)).toEqual({
+      deadlineSource: 'model',
+      policyId: null,
+      citation: null,
+    });
+    expect(resolveProvenance(undefined, REFERENCES).deadlineSource).toBe('model');
+  });
+
+  it('refuses an excerpt number that was never supplied', () => {
+    // The failure this exists to prevent: a confident citation to a provision
+    // the model did not read, on a statutory deadline.
+    expect(resolveProvenance(3, REFERENCES).deadlineSource).toBe('model');
+    expect(resolveProvenance(99, REFERENCES).deadlineSource).toBe('model');
+    expect(resolveProvenance(3, REFERENCES).citation).toBeNull();
+  });
+
+  it('refuses zero, negatives and non-integers', () => {
+    for (const n of [0, -1, 1.5, NaN]) {
+      expect(resolveProvenance(n, REFERENCES).deadlineSource).toBe('model');
+    }
+  });
+
+  it('refuses everything when no excerpts were retrieved', () => {
+    // An empty library must not be able to produce a policy-backed deadline.
+    for (const n of [1, 2, null]) {
+      expect(resolveProvenance(n, []).deadlineSource).toBe('model');
+    }
+  });
+});

--- a/src/lib/obligation-provenance.ts
+++ b/src/lib/obligation-provenance.ts
@@ -1,0 +1,45 @@
+import type { PolicyReference } from '@/types';
+
+/** Where an obligation's deadline came from. */
+export type DeadlineSource = 'policy' | 'model';
+
+export interface Provenance {
+  deadlineSource: DeadlineSource;
+  policyId: string | null;
+  citation: string | null;
+}
+
+const UNVERIFIED: Provenance = { deadlineSource: 'model', policyId: null, citation: null };
+
+/**
+ * Resolve the model's claim about where a deadline came from.
+ *
+ * The model is asked to name the numbered excerpt that states the deadline.
+ * That is a claim about its own reasoning, and it is worth exactly nothing
+ * until it is checked: an excerpt number that does not correspond to text the
+ * model was actually given cannot support anything. So the number is looked up
+ * in the excerpts that were supplied, and anything that fails to resolve --
+ * invented, off-by-one, out of range, or absent -- produces an unverified
+ * obligation rather than a confident citation to the wrong provision.
+ *
+ * Unverified is not a failure state. It is the honest description of a
+ * deadline the loaded policy does not state, and with a thin library it is the
+ * common case. What must never happen is the reverse: an obligation presented
+ * as policy-backed when nothing retrieved supports it. (OQ-5)
+ */
+export function resolveProvenance(
+  sourceExcerpt: number | null | undefined,
+  references: PolicyReference[]
+): Provenance {
+  if (sourceExcerpt === null || sourceExcerpt === undefined) return UNVERIFIED;
+  if (!Number.isInteger(sourceExcerpt)) return UNVERIFIED;
+
+  const reference = references.find(r => r.n === sourceExcerpt);
+  if (!reference) return UNVERIFIED;
+
+  return {
+    deadlineSource: 'policy',
+    policyId: reference.policyId,
+    citation: reference.citation,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -346,6 +346,24 @@ export interface PolicyChunk {
   sectionStatute?: string | null;
 }
 
+/**
+ * One numbered excerpt as it was presented to the model.
+ *
+ * The prompt hands the model `[1] JICK §D — ... <text>` and asks it to name the
+ * excerpt a deadline came from. That claim is then resolved against this list:
+ * an excerpt number the model invented does not appear here, so the attribution
+ * fails and the obligation is recorded as model-sourced. Trusting the claim
+ * instead would mean the citation on an obligation is only as good as the
+ * model's honesty about its own reasoning. (OQ-5)
+ */
+export interface PolicyReference {
+  /** The number the excerpt was given in the prompt, 1-based. */
+  n: number;
+  policyId: string;
+  /** Formatted reference, e.g. "JICK §F — Investigative Procedures (RSA ...)". */
+  citation: string;
+}
+
 /** One policy cited in a response, with enough detail for the UI to show it. */
 export interface PolicyCitation {
   policyId: string;


### PR DESCRIPTION
Closes the last blocker from the 2026-09-01 audit (B1).

## The problem

The deadline on a `ComplianceAction` was produced by a classification call that
was **never shown a policy**. Classification has to run before retrieval — its
categories are what retrieval filters on — so `classifyIncident`'s third
parameter was always `undefined` and the model was asked to recall New
Hampshire law from training. Three UI surfaces told the administrator it came
from the policy, and the row had no column that could represent the difference.

## What changes

Obligations are created in a **second pass, after retrieval**, with the
excerpts in hand. Each records whether a retrieved excerpt states its deadline.

**The attribution is checked, not trusted.** The model names the numbered
excerpt a deadline came from; `resolveProvenance` looks that number up in the
excerpts actually supplied. Invented, off-by-one, out of range or absent → an
unverified obligation, never a confident citation to the wrong provision.
Verified by making the resolver fall back to the first excerpt: two tests fail.

**Unverified is not a failure state, and the obligation is never dropped.**
"Report this to DCYF" is worth saying whether or not a deadline can be
attributed — suppressing it is how a mandated report gets missed. What changes
is what it may *claim*:

- no red or amber (colour here means a deadline state; an unsubstantiated one
  hasn't earned it)
- a line on its own row: *"Deadline not found in the loaded policy — confirm it
  before acting."*
- excluded from the "N things are late" count — the number in the product that
  most looks like fact

The home headline and the API tallies now apply the same rule. They had already
drifted apart (DEAD-60); this is where that would have bitten.

## FLOW-35, fixed alongside

It produces the same rows. A failed classification returned `other` / `low` /
no obligations, which the route wrote **permanently** — so an API timeout and a
genuine "we could not tell" became the same record, on the incident where the
system knew least. It now throws, `incidentType` stays null, the next turn
retries. `getDefaultClassification` is removed rather than left unused: a
plausible-looking safe default is exactly what someone would re-wire.

## Expect this to look quiet at first

With `mandatory_reporting` still unloaded, most obligations will be unverified.
That's the honest reading, not a regression — the system saying it couldn't
find the rule instead of asserting one. It gets more useful as the library
fills.

## What this deliberately does not do

It verifies the excerpt **exists and was supplied**, not that the excerpt
*states the deadline claimed*. A model citing a real excerpt for a number that
excerpt doesn't contain still produces a policy-backed row. Closing that needs
the deadline parsed out of the provision text, and wants real incidents to
calibrate against — recorded in the roadmap against step 6.

Migration is additive: three nullable-or-defaulted columns and a `SetNull`
foreign key, so deleting a policy costs an obligation its citation rather than
the obligation. Every pre-existing row is correctly described as `model`.

| | before | after |
|---|---|---|
| typecheck | 0 | 0 |
| lint | 0 errors | 0 errors |
| build | clean | clean |
| unit | 121 | **127** |
| e2e | 54 | **56** |

No suppressions in the diff.