### PR TITLE
OQ-2: one ingestion path, one uploads directory

### DIFF
--- a/QUICK_START_POLICY_UPLOAD.md
+++ b/QUICK_START_POLICY_UPLOAD.md
@@ -32,28 +32,37 @@
 
 ### Method 2: Single Policy Upload (Command Line)
 
-**Best for:** Quick testing or single policy upload
+**Best for:** loading one policy, and the path that actually works today.
 
-`POST /api/policies` requires an **admin session** — it is not open. Sign in
-through the UI, copy the `authjs.session-token` cookie from your browser, and
-pass it as shown. Without it the request returns 401.
+Use `npm run policies:load`. It writes through Prisma, so it needs no running
+server and no session cookie, it accepts `.pdf` and `.docx` as well as text,
+and it **dry-runs by default** — you see what it would create before it writes.
 
 ```bash
-curl -X POST http://localhost:3000/api/policies \
-  -H "Cookie: authjs.session-token=$SESSION_TOKEN" \
-  -F "title=JLDBB - Suicide Prevention" \
-  -F "jurisdiction=district" \
-  -F "category=suicide_prevention" \
-  -F "effectiveDate=2024-01-01" \
-  -F "file=@sample-policies/jldbb-suicide-prevention.pdf"
+npm run policies:load -- \
+  --file sample-policies/jldbb-suicide-prevention.pdf \
+  --title "JLDBB - Suicide Prevention" \
+  --jurisdiction district \
+  --category suicide_prevention \
+  --effective 2024-01-01
+# then repeat with --apply to write
 ```
 
 **Replace:**
-- `title` → Your policy title
-- `jurisdiction` → `federal`, `state`, `district` or `school` (see below)
-- `category` → one of the 20 categories (see below)
-- `effectiveDate` → YYYY-MM-DD format
-- `file=@...` → Path to your policy file
+- `--title` → Your policy title
+- `--jurisdiction` → `federal`, `state`, `district` or `school` (see below)
+- `--category` → one of the 20 categories (see below); it is validated, and a
+  typo is rejected rather than stored as `other`
+- `--effective` → YYYY-MM-DD format
+- `--file` → Path to your policy file
+
+It refuses a document from which fewer than 50 words could be extracted, which
+is what a scanned PDF looks like.
+
+`POST /api/policies` used to be documented here. It is gone: it was the third
+of three ingestion routes, called by nothing, and it sat outside the
+`/api/admin` prefix that the middleware gates. The HTTP path is now
+`POST /api/admin/policies/upload`, which the admin UI uses.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ paths exist; see `QUICK_START_POLICY_UPLOAD.md` for detail.
    `scripts/batch-upload-policies.ts` first, and put the files in
    `sample-policies/`.
 2. The admin UI at `/admin/policies` (`.txt`, `.md`, `.pdf`, `.docx`).
-3. `POST /api/policies` directly.
 
 All three now index through the same chunker (1000 words, 200-word overlap)
 and generate embeddings when configured. For a single document:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,14 +233,29 @@ Also fix `FLOW-35` alongside it: a failed classification should leave
 `incidentType` null so the next turn retries, rather than stamping `other`
 permanently with no way to correct it.
 
-**OQ-2 — canonical ingestion: `/api/admin/policies/upload`.** *(Queued.)*
+**OQ-2 — canonical ingestion: `/api/admin/policies/upload`. Done 2026-09-02.**
 Delete `POST /api/policies`; keep `POST /api/admin/policies` for the paste-text
 path the admin UI uses. The deleted route is called by no client, sits outside
 the `/api/admin` prefix so `isAdminPath` does not cover it, and is the route
 SEC-3 exploited. It is documented in README, so this needs a doc change — that
-is the decision, not an obstacle. Standardise the uploads directory on one
-resolution at the same time (DEAD-62): there are four, and one makes
-`policies:reindex` re-copy the source file on every run.
+is the decision, not an obstacle. Standardised the uploads directory at the same time
+(DEAD-62). There were four resolutions across six call sites, and two were
+wrong in ways only a deployment shows:
+
+- `join(cwd, UPLOADS_DIR, 'attachments')` prefixes the working directory to an
+  absolute path, so `UPLOADS_DIR=/app/uploads` resolved to
+  `/app/app/uploads/attachments` — **outside the Azure Files mount**. Upload and
+  download shared the same wrong expression, so the app worked perfectly until
+  the first redeploy, at which point every attachment was gone with no error.
+  This would have shipped with the Azure work.
+- `join(cwd, 'uploads', 'policies')` ignored `UPLOADS_DIR` entirely, so
+  `policies:reindex`'s containment check never matched and it re-copied every
+  source file on every run.
+
+All six now go through `uploadsRoot()` / `policyUploadsDir()` /
+`attachmentUploadsDir()` in `src/lib/uploads.ts`, with tests covering the
+absolute case. SEC-27 closed alongside: `GET /api/policies` returned whole
+rows, including absolute server paths, to any authenticated user.
 
 **OQ-4 — the admin-editable system prompt: invert it, but not yet.** *(Queued,
 lowest priority.)* The row replaces the in-code prompt for the chat path only —

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -48,7 +48,6 @@ test.describe('Navigation', () => {
       ['post', '/api/admin/prompts'],
       ['put', '/api/admin/prompts/any-id'],
       ['delete', '/api/admin/prompts/any-id'],
-      ['post', '/api/policies'],
     ];
 
     for (const [method, url] of attempts) {
@@ -60,6 +59,13 @@ test.describe('Navigation', () => {
         `${method.toUpperCase()} ${url} should be refused for a reporter`
       ).toBe(403);
     }
+
+    // The third ingestion route is gone: called by nothing, and outside the
+    // /api/admin prefix the middleware gates, so its handler guard was the only
+    // thing holding. Reading the library is still allowed. (OQ-2)
+    const removed = await page.request.post('/api/policies', { data: {} });
+    expect(removed.status()).toBe(405);
+    expect((await page.request.get('/api/policies?active=true')).status()).toBe(200);
   });
 
   test('the health probe is reachable without a session and says nothing else', async ({

--- a/scripts/load-policy.ts
+++ b/scripts/load-policy.ts
@@ -6,6 +6,7 @@ import { prisma } from '../src/lib/db';
 import { ragSystem } from '../src/lib/ai/rag';
 import { processDocument } from '../src/lib/utils/documentProcessor';
 import { POLICY_CATEGORIES, POLICY_JURISDICTIONS } from '../src/types';
+import { policyUploadsDir } from '../src/lib/uploads';
 
 config({ path: resolve(__dirname, '../.env') });
 
@@ -101,7 +102,7 @@ async function main() {
 
   // Keep a copy of the source. Re-indexing re-extracts from it, so the
   // provenance cannot depend on the operator's download folder still existing.
-  const uploadsDir = resolve(process.env.UPLOADS_DIR ?? './uploads', 'policies');
+  const uploadsDir = policyUploadsDir();
   mkdirSync(uploadsDir, { recursive: true });
   const stored = resolve(uploadsDir, `${randomUUID()}${extname(file).toLowerCase()}`);
   copyFileSync(file, stored);

--- a/scripts/reindex-policies.ts
+++ b/scripts/reindex-policies.ts
@@ -5,8 +5,9 @@ import { randomUUID } from 'crypto';
 import { prisma } from '../src/lib/db';
 import { processDocument } from '../src/lib/utils/documentProcessor';
 
-const policyUploadsDir = resolve(process.env.UPLOADS_DIR ?? './uploads', 'policies');
+
 import { ragSystem } from '../src/lib/ai/rag';
+import { policyUploadsDir } from '../src/lib/uploads';
 
 config({ path: resolve(__dirname, '../.env') });
 
@@ -119,9 +120,10 @@ async function main() {
         // re-index silently falls back to stored content and drops every
         // section label, with nothing in the output saying why.
         let filePath = policy.filePath;
-        if (!resolve(filePath).startsWith(policyUploadsDir + sep)) {
-          const adopted = resolve(policyUploadsDir, `${randomUUID()}${extname(filePath).toLowerCase()}`);
-          mkdirSync(policyUploadsDir, { recursive: true });
+        const policyDir = policyUploadsDir();
+        if (!resolve(filePath).startsWith(policyDir + sep)) {
+          const adopted = resolve(policyDir, `${randomUUID()}${extname(filePath).toLowerCase()}`);
+          mkdirSync(policyDir, { recursive: true });
           copyFileSync(filePath, adopted);
           filePath = adopted;
           console.log(`         adopted source into ${relative(process.cwd(), adopted)}`);

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { ragSystem } from '@/lib/ai/rag';
 import { writeFile, mkdir, unlink } from 'fs/promises';
-import { join } from 'path';
 import { existsSync } from 'fs';
 import { processDocument } from '@/lib/utils/documentProcessor';
 import { safeFetchText, UnsafeUrlError } from '@/lib/safe-fetch';
@@ -14,6 +13,7 @@ import {
   safeUploadPath,
   UploadError,
   uploadErrorStatus,
+  policyUploadsDir,
 } from '@/lib/uploads';
 import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
       const ext = assertAllowedExtension(file.name, ALLOWED_POLICY_EXTENSIONS);
       assertWithinSizeLimit(file);
 
-      const uploadsDir = join(process.cwd(), 'uploads', 'policies');
+      const uploadsDir = policyUploadsDir();
       if (!existsSync(uploadsDir)) {
         await mkdir(uploadsDir, { recursive: true });
       }

--- a/src/app/api/attachments/[id]/route.ts
+++ b/src/app/api/attachments/[id]/route.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/db';
 import { canReadAllIncidents, requireUser } from '@/lib/session';
 import { createErrorResponse, notFoundError } from '@/lib/errors';
 import { recordAudit } from '@/lib/audit';
+import { attachmentUploadsDir } from '@/lib/uploads';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -41,11 +42,7 @@ export async function GET(request: NextRequest, { params }: Params) {
     // not read it.
     if (!permitted) return notFoundError('Attachment');
 
-    const uploadsDir = join(
-      process.cwd(),
-      process.env.UPLOADS_DIR || './uploads',
-      'attachments'
-    );
+    const uploadsDir = attachmentUploadsDir();
     const filePath = join(uploadsDir, attachment.filePath);
 
     // filePath is a server-generated basename, but assert containment anyway

--- a/src/app/api/attachments/upload/route.ts
+++ b/src/app/api/attachments/upload/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { writeFile, mkdir } from 'fs/promises';
-import { join } from 'path';
 import { existsSync } from 'fs';
 import {
   assertAllowedExtension,
   assertWithinSizeLimit,
   safeUploadPath,
   UploadError,
+  attachmentUploadsDir,
 } from '@/lib/uploads';
 import { incidentScope, requireUser } from '@/lib/session';
 
@@ -59,11 +59,7 @@ export async function POST(request: NextRequest) {
     // path handed out by GET /api/incidents/[id] was a direct download link for
     // anyone. They are now written outside the served tree and read back only
     // through GET /api/attachments/[id], which re-checks the session. (SEC-5)
-    const uploadsDir = join(
-      process.cwd(),
-      process.env.UPLOADS_DIR || './uploads',
-      'attachments'
-    );
+    const uploadsDir = attachmentUploadsDir();
     if (!existsSync(uploadsDir)) {
       await mkdir(uploadsDir, { recursive: true });
     }

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,23 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
-import { ragSystem } from '@/lib/ai/rag';
-import { processDocument } from '@/lib/utils/documentProcessor';
 import { POLICY_CATEGORIES, POLICY_JURISDICTIONS } from '@/types';
-import { mkdir, writeFile } from 'fs/promises';
-import { existsSync } from 'fs';
-import {
-  assertAllowedExtension,
-  assertWithinSizeLimit,
-  safeUploadPath,
-  UploadError,
-  assertIndexablePolicyText,
-} from '@/lib/uploads';
-import { requireRole, requireUser } from '@/lib/session';
-import { policyFacetsSchema } from '@/lib/validation';
-import { validationError } from '@/lib/errors';
-import { recordAudit } from '@/lib/audit';
-
-const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
+import { requireUser } from '@/lib/session';
 
 export async function GET(request: NextRequest) {
   try {
@@ -44,6 +28,18 @@ export async function GET(request: NextRequest) {
 
     const policies = await prisma.policy.findMany({
       where,
+      // Explicit projection. This returned whole rows, so any authenticated
+      // user could read `content` and `filePath` -- an absolute server path,
+      // which is reconnaissance for the path-traversal bug class this codebase
+      // has already shipped twice. The library page uses six fields. (SEC-27)
+      select: {
+        id: true,
+        title: true,
+        jurisdiction: true,
+        category: true,
+        effectiveDate: true,
+        isActive: true,
+      },
       orderBy: { createdAt: 'desc' },
     });
 
@@ -57,100 +53,11 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    // Policy ingestion is an admin action. (SEC-6)
-    const guard = await requireRole('admin');
-    if (!guard.ok) return guard.response;
-
-    const formData = await request.formData();
-    const title = formData.get('title') as string;
-    const facets = policyFacetsSchema.safeParse({
-      jurisdiction: formData.get('jurisdiction'),
-      category: formData.get('category'),
-    });
-    if (!facets.success) {
-      return validationError(
-        'Jurisdiction and category must each be one of the known values',
-        facets.error.flatten().fieldErrors
-      );
-    }
-    const { jurisdiction, category } = facets.data;
-    const effectiveDate = formData.get('effectiveDate') as string;
-    const file = formData.get('file') as File;
-
-    if (!title) {
-      return NextResponse.json(
-        { error: 'Title and policy type are required' },
-        { status: 400 }
-      );
-    }
-
-    let content = '';
-    let filePath = '';
-
-    if (file) {
-      // Validate before writing. The previous implementation concatenated
-      // `file.name` straight into the path, so a `../` filename escaped the
-      // uploads directory entirely. (SEC-3, SEC-10)
-      const ext = assertAllowedExtension(file.name, ALLOWED_POLICY_EXTENSIONS);
-      assertWithinSizeLimit(file);
-
-      const uploadsDir = process.env.UPLOADS_DIR || './uploads';
-      if (!existsSync(uploadsDir)) {
-        await mkdir(uploadsDir, { recursive: true });
-      }
-
-      const uploadPath = safeUploadPath(uploadsDir, ext);
-      await writeFile(uploadPath, Buffer.from(await file.arrayBuffer()));
-      filePath = uploadPath;
-
-      // Extract text content
-      const processed = await processDocument(uploadPath);
-      content = processed.content;
-    }
-
-    assertIndexablePolicyText(content);
-
-    // Create policy record
-    const policy = await prisma.policy.create({
-      data: {
-        title,
-        content,
-        filePath,
-        jurisdiction,
-        category,
-        effectiveDate: effectiveDate ? new Date(effectiveDate) : new Date(),
-        isActive: true,
-      },
-    });
-    await recordAudit({
-      userId: guard.user.id,
-      action: 'created',
-      entity: 'policy',
-      entityId: policy.id,
-      details: { title: policy.title, jurisdiction: policy.jurisdiction, category: policy.category },
-    });
-
-    // Add to RAG system for search with metadata
-    if (content) {
-      await ragSystem.addPolicyDocument(policy.id, content, {
-        title,
-        jurisdiction,
-        category,
-        effectiveDate: effectiveDate || new Date().toISOString(),
-      });
-    }
-
-    return NextResponse.json({ policy });
-  } catch (error) {
-    console.error('Create policy error:', error);
-    if (error instanceof UploadError) {
-      return NextResponse.json({ error: error.message }, { status: error.status });
-    }
-    return NextResponse.json(
-      { error: 'Failed to create policy' },
-      { status: 500 }
-    );
-  }
-}
+// POST is gone. It was the third of three ingestion routes, called by no
+// client, and it sat outside the /api/admin prefix -- so `isAdminPath` in
+// auth.config.ts did not cover it and the handler's own requireRole was the
+// only thing holding. It is also the route SEC-3 exploited.
+//
+// The canonical path is POST /api/admin/policies/upload (file or URL), with
+// POST /api/admin/policies for pasted text. Both live behind the prefix the
+// middleware gates, and both write to policyUploadsDir(). (OQ-2)

--- a/src/lib/uploads.test.ts
+++ b/src/lib/uploads.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { resolve, sep } from 'path';
 import {
   assertAllowedExtension,
+  attachmentUploadsDir,
+  policyUploadsDir,
+  uploadsRoot,
   assertIndexablePolicyText,
   assertWithinSizeLimit,
   DEFAULT_MAX_UPLOAD_BYTES,
@@ -141,6 +144,44 @@ describe('assertIndexablePolicyText', () => {
       throw new Error('expected a throw');
     } catch (error) {
       expect((error as { status?: number }).status).toBe(422);
+    }
+  });
+});
+
+describe('uploads directory resolution', () => {
+  const original = process.env.UPLOADS_DIR;
+  afterEach(() => {
+    if (original === undefined) delete process.env.UPLOADS_DIR;
+    else process.env.UPLOADS_DIR = original;
+  });
+
+  it('honours an absolute UPLOADS_DIR instead of prefixing the working directory', () => {
+    // The bug this replaces: join(cwd, '/app/uploads', 'attachments') gives
+    // /app/app/uploads/attachments. On a container platform that is outside
+    // the mounted volume, so every attachment -- student records -- is
+    // destroyed on the next revision. Upload and download shared the same
+    // wrong expression, so nothing failed until a redeploy. (OQ-2, DEAD-62)
+    process.env.UPLOADS_DIR = '/srv/files';
+    expect(uploadsRoot()).toBe('/srv/files');
+    expect(attachmentUploadsDir()).toBe('/srv/files/attachments');
+    expect(policyUploadsDir()).toBe('/srv/files/policies');
+  });
+
+  it('resolves a relative UPLOADS_DIR against the working directory', () => {
+    process.env.UPLOADS_DIR = './uploads';
+    expect(policyUploadsDir()).toBe(resolve(process.cwd(), 'uploads', 'policies'));
+  });
+
+  it('defaults to ./uploads when unset', () => {
+    delete process.env.UPLOADS_DIR;
+    expect(uploadsRoot()).toBe(resolve(process.cwd(), 'uploads'));
+  });
+
+  it('keeps policies and attachments apart under one root', () => {
+    process.env.UPLOADS_DIR = '/srv/files';
+    expect(policyUploadsDir()).not.toBe(attachmentUploadsDir());
+    for (const dir of [policyUploadsDir(), attachmentUploadsDir()]) {
+      expect(dir.startsWith(uploadsRoot() + sep)).toBe(true);
     }
   });
 });

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -95,6 +95,43 @@ export function safeUploadPath(uploadsDir: string, ext: string): string {
  * Lives here, with the other upload rules, because there are three ingestion
  * routes and a guard on one of them is not a guard.
  */
+/**
+ * Where uploaded files live, resolved one way.
+ *
+ * There were four expressions for this across six call sites, and they
+ * disagreed. Two were wrong in ways that only show up in deployment:
+ *
+ *   join(cwd, UPLOADS_DIR, 'attachments')
+ *
+ * silently prefixes the working directory to an absolute path, so
+ * UPLOADS_DIR=/app/uploads resolves to /app/app/uploads/attachments -- outside
+ * the mounted volume, on a container platform where anything outside the mount
+ * dies with the revision. Upload and download shared the same wrong expression,
+ * so the app worked perfectly until the first redeploy, at which point every
+ * attachment -- student records -- was gone with no error anywhere.
+ *
+ * And `join(cwd, 'uploads', 'policies')` ignored UPLOADS_DIR entirely, so a
+ * policy written by one route was not where `policies:reindex` looked, and its
+ * containment check therefore failed every time and re-copied the file on
+ * every run.
+ *
+ * `resolve` is the fix: it honours an absolute UPLOADS_DIR and resolves a
+ * relative one against the working directory. (OQ-2, DEAD-62)
+ */
+export function uploadsRoot(): string {
+  return resolve(process.env.UPLOADS_DIR ?? './uploads');
+}
+
+/** Policy source documents. `policies:reindex` re-extracts from these. */
+export function policyUploadsDir(): string {
+  return resolve(uploadsRoot(), 'policies');
+}
+
+/** Attachments. Student records: never under `public/`, never in the image. */
+export function attachmentUploadsDir(): string {
+  return resolve(uploadsRoot(), 'attachments');
+}
+
 export function assertIndexablePolicyText(content: string): void {
   if (countWords(content) === 0) {
     throw new UploadError(


### PR DESCRIPTION
Independent of #19 — both branch from `dev`; merge in either order.

## The part that matters

The uploads directory had **four resolutions across six call sites**, and two
were wrong in ways only a deployment shows.

```js
join(cwd, UPLOADS_DIR, 'attachments')
```

prefixes the working directory to an absolute path. With the
`UPLOADS_DIR=/app/uploads` I set in the Azure deployment, that resolves to
`/app/app/uploads/attachments` — **outside the Azure Files mount**, where
nothing survives a revision. Upload and download shared the same wrong
expression, so the app works perfectly within a container's lifetime and every
attachment (student records) vanishes on the first redeploy, with no error
anywhere.

**That would have shipped with the Azure work.** It's the exact failure
`docs/deploy-azure.md` warns about, caused by code rather than config.

The other: `join(cwd, 'uploads', 'policies')` ignored `UPLOADS_DIR` entirely,
so a policy written by the admin route wasn't where `policies:reindex` looked —
its containment check never matched and it re-copied the source file on every
run.

All six now go through `uploadsRoot()` / `policyUploadsDir()` /
`attachmentUploadsDir()`, using `resolve`, with four unit tests including the
absolute case.

## The route deletion

`POST /api/policies` is gone. Third of three ingestion routes, called by no
client, and sitting **outside** the `/api/admin` prefix — so `isAdminPath`
didn't cover it and the handler's own `requireRole` was the only thing holding.
It's also the route SEC-3 exploited.

Canonical: `POST /api/admin/policies/upload` (file or URL),
`POST /api/admin/policies` (pasted text). Both behind the gated prefix.

The admin-authorization e2e caught the deletion on the first run — it now
asserts the route is *gone* (405) rather than merely refused, and that reading
the library still works.

## Also closes SEC-27

`GET /api/policies` returned whole rows to any authenticated user, including
`content` and `filePath` — an absolute server path, which is reconnaissance for
the path-traversal bug class this codebase has already shipped twice. Now an
explicit projection of the six fields the library page uses.

## Docs

QUICK_START's "Method 2" documented the deleted route. It now documents
`policies:load`, which needs no server and no session cookie, accepts PDF and
DOCX, validates the category rather than defaulting it to `other`, and
**dry-runs by default**.

| | |
|---|---|
| typecheck | 0 errors |
| lint | 0 errors, 3 pre-existing warnings |
| build | clean |
| unit | **125** |
| e2e | 54 |