### PR TITLE
Rate limiting (SEC-11, SEC-23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,9 +306,12 @@ saying it could not find the rule, instead of asserting one.
 
 Still open, and worth knowing before you deploy:
 
-- **No rate limiting** on the LLM endpoints. They are authenticated now, so
-  this is a cost and abuse concern rather than an open door, but a single
-  signed-in user can still run up the Anthropic bill.
+- **Rate limiting is in-process, not shared.** Sign-in is limited by client
+  address in `middleware.ts`; chat, summaries and uploads are limited by user
+  id in their handlers. The counters live in the server's memory, which is
+  exact at one replica and wrong at more than one — with N replicas the
+  effective limit becomes N times what is configured. It degrades quietly, so
+  move it to a shared store *before* raising `maxReplicas`.
 - **DNS rebinding** is not fully mitigated in the policy URL fetch; the
   hostname allowlist described in SEC-4 is the real fix.
 - **Upload size limits** reject oversized files but do not prevent memory

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -278,6 +278,38 @@ cost.
 
 ---
 
+### ~~Rate limiting (SEC-11 / SEC-23)~~ — **done 2026-09-02**
+
+`/api/auth/*` is public, and `src/auth.ts` runs `bcrypt.compare` at cost 12
+deliberately even for an address with no account — so every attempt cost
+roughly a quarter-second of *blocking* CPU on a single event loop. A few
+hundred a minute made the app unavailable to every administrator while also
+giving unbounded password guessing. `rateLimitError()` had been exported since
+the first audit and imported by nothing.
+
+Sign-in is limited by client address in `middleware.ts` (10 per 5 minutes),
+because it is NextAuth's own route and there is no handler of ours to put it
+in. Chat, summaries and uploads are limited by user id in their handlers — the
+bound there is on what one account can spend, and keying by address would put
+every administrator behind a school's NAT on one counter.
+
+**The counters are in this process's memory.** That is exact at one replica,
+which is what the Container Apps config pins, and wrong at more than one: with
+N replicas the effective limit becomes N times what is configured. It degrades
+quietly rather than failing, so it must move to a shared store *before*
+`maxReplicas` is raised.
+
+`src/lib/rate-limit.ts` deliberately imports nothing. `middleware.ts` runs on
+the Edge runtime, and an early version had it import `errors.ts`, which pulled
+Prisma into that bundle and failed the build. The counter is pure; the response
+helper lives with the other response helpers.
+
+Seven unit tests, and an e2e that floods the sign-in endpoint and asserts a 429
+with a `Retry-After` that leaks nothing about whether the account exists —
+verified to fail when the limiter is removed.
+
+---
+
 ## Next — gated on real use
 
 ### 6. Run a real incident end to end, and watch it — *maintainer*

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { RATE_LIMITS } from '../src/lib/rate-limit';
 
 test.describe('Navigation', () => {
   test('navigates to the main pages from the navbar', async ({ page }) => {
@@ -78,6 +79,38 @@ test.describe('Navigation', () => {
     const response = await anonymous.request.get('/api/health');
     expect(response.status()).toBe(200);
     expect(await response.json()).toEqual({ status: 'ok' });
+    await anonymous.close();
+  });
+
+  test('the sign-in endpoint refuses a flood, and says nothing about the account', async ({
+    browser,
+  }) => {
+    // The one unauthenticated write path. bcrypt at cost 12 runs even for an
+    // address with no account, so each attempt costs ~0.25s of blocking CPU on
+    // a single event loop -- a few hundred a minute take the app down for every
+    // administrator, and password guessing was unbounded. (SEC-11, SEC-23)
+    const anonymous = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+
+    let sawRateLimit = false;
+    let status = 0;
+    for (let i = 0; i < RATE_LIMITS.SIGN_IN.limit + 3; i++) {
+      const response = await anonymous.request.post('/api/auth/callback/credentials', {
+        form: { email: `flood-${i}@example.org`, password: 'wrong-password' },
+        maxRedirects: 0,
+      });
+      status = response.status();
+      if (status === 429) {
+        sawRateLimit = true;
+        // Tells the caller when to come back, and nothing else.
+        expect(Number(response.headers()['retry-after'])).toBeGreaterThan(0);
+        const body = await response.json();
+        expect(body.code).toBe('RATE_LIMIT_EXCEEDED');
+        expect(JSON.stringify(body)).not.toContain('flood-');
+        break;
+      }
+    }
+
+    expect(sawRateLimit, `expected a 429 within the window, last status ${status}`).toBe(true);
     await anonymous.close();
   });
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import NextAuth from 'next-auth';
+import { NextResponse, type NextRequest } from 'next/server';
 import { authConfig } from '@/auth.config';
+import { checkRateLimit, RATE_LIMITS } from '@/lib/rate-limit';
 
 /**
  * Deny-by-default gate in front of every page and API route.
@@ -7,7 +9,56 @@ import { authConfig } from '@/auth.config';
  * Uses the Edge-safe config only -- no Prisma, no bcrypt. The `authorized`
  * callback in src/auth.config.ts holds the rules.
  */
-export const { auth: middleware } = NextAuth(authConfig);
+const authMiddleware = NextAuth(authConfig).auth;
+
+/**
+ * The sign-in endpoint is rate limited here rather than in a handler, because
+ * it is NextAuth's own route and there is no handler of ours to put it in.
+ *
+ * This is the one unauthenticated write path in the application. `src/auth.ts`
+ * runs `bcrypt.compare` at cost 12 deliberately even for an address with no
+ * account, so every attempt costs roughly a quarter-second of *blocking* CPU on
+ * a single event loop: a few hundred a minute make the app unavailable to every
+ * administrator, while also giving unbounded password guessing. (SEC-11/SEC-23)
+ *
+ * Keyed by client address. Behind Azure Container Apps' ingress the real
+ * address is in x-forwarded-for, and its first entry is the one the edge saw.
+ */
+function clientAddress(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0]!.trim();
+  return request.headers.get('x-real-ip') ?? 'unknown';
+}
+
+function isCredentialsSignIn(request: NextRequest): boolean {
+  return (
+    request.method === 'POST' &&
+    request.nextUrl.pathname.startsWith('/api/auth/callback/credentials')
+  );
+}
+
+export default function middleware(request: NextRequest, event: never) {
+  if (isCredentialsSignIn(request)) {
+    const { limit, windowMs } = RATE_LIMITS.SIGN_IN;
+    const result = checkRateLimit(`signin:${clientAddress(request)}`, limit, windowMs);
+    if (!result.allowed) {
+      // A plain 429, with no hint about whether the address exists.
+      return NextResponse.json(
+        {
+          error: 'Too many requests',
+          message: 'Too many sign-in attempts. Please wait and try again.',
+          code: 'RATE_LIMIT_EXCEEDED',
+        },
+        { status: 429, headers: { 'Retry-After': String(result.retryAfterSeconds) } }
+      );
+    }
+  }
+
+  return (authMiddleware as unknown as (r: NextRequest, e: never) => unknown)(
+    request,
+    event
+  ) as ReturnType<typeof NextResponse.next>;
+}
 
 export const config = {
   matcher: [

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -19,6 +19,8 @@ import { requireRole } from '@/lib/session';
 import { policyFacetsSchema } from '@/lib/validation';
 import { validationError } from '@/lib/errors';
 import { recordAudit } from '@/lib/audit';
+import { enforceRateLimit } from '@/lib/errors';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
 /** Formats the documentProcessor can actually parse. */
 const ALLOWED_POLICY_EXTENSIONS = ['.txt', '.md', '.pdf', '.docx', '.doc'] as const;
@@ -30,6 +32,9 @@ export async function POST(request: NextRequest) {
     // mistake must not silently expose policy or prompt mutation. (SEC-6)
     const guard = await requireRole('admin');
     if (!guard.ok) return guard.response;
+
+    const limited = enforceRateLimit(`policy-upload:${guard.user.id}`, RATE_LIMITS.UPLOAD);
+    if (limited) return limited;
 
     const formData = await request.formData();
     const file = formData.get('file') as File | null;

--- a/src/app/api/attachments/upload/route.ts
+++ b/src/app/api/attachments/upload/route.ts
@@ -10,6 +10,8 @@ import {
   attachmentUploadsDir,
 } from '@/lib/uploads';
 import { incidentScope, requireUser } from '@/lib/session';
+import { enforceRateLimit } from '@/lib/errors';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
 /**
  * Deliberately excludes .html/.svg/.xhtml: these files are served from
@@ -25,6 +27,9 @@ export async function POST(request: NextRequest) {
   try {
     const guard = await requireUser();
     if (!guard.ok) return guard.response;
+
+    const limited = enforceRateLimit(`upload:${guard.user.id}`, RATE_LIMITS.UPLOAD);
+    if (limited) return limited;
 
     const formData = await request.formData();
     const file = formData.get('file') as File;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,6 +13,8 @@ import { incidentScope, requireUser } from '@/lib/session';
 import { actionTypeFor, ClassificationUnavailableError } from '@/lib/ai/classifier';
 import { resolveProvenance } from '@/lib/obligation-provenance';
 import { claudeService } from '@/lib/ai/claude-service';
+import { enforceRateLimit } from '@/lib/errors';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
@@ -23,6 +25,12 @@ export async function POST(request: NextRequest) {
 
     const guard = await requireUser();
     if (!guard.ok) return guard.response;
+
+    // One turn can trigger classification, obligation derivation and the
+    // guidance call, so this bounds billed spend as well as load. Keyed by
+    // user: the limit is on what an account can spend. (SEC-23)
+    const limited = enforceRateLimit(`chat:${guard.user.id}`, RATE_LIMITS.CHAT);
+    if (limited) return limited;
     userId = guard.user.id;
 
     const body = await request.json();

--- a/src/app/api/chat/summary/route.ts
+++ b/src/app/api/chat/summary/route.ts
@@ -3,6 +3,8 @@ import { createErrorResponse, notFoundError, validationError } from '@/lib/error
 import { requireUser } from '@/lib/session';
 import { generateIncidentSummary } from '@/lib/ai/incident-summary';
 import { recordAudit } from '@/lib/audit';
+import { enforceRateLimit } from '@/lib/errors';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
 /**
  * POST /api/chat/summary — end-of-chat summary.
@@ -17,6 +19,9 @@ export async function POST(request: NextRequest) {
   try {
     const guard = await requireUser();
     if (!guard.ok) return guard.response;
+
+    const limited = enforceRateLimit(`summary:${guard.user.id}`, RATE_LIMITS.CHAT);
+    if (limited) return limited;
 
     const { incidentId } = await request.json();
     if (!incidentId || typeof incidentId !== 'string') {

--- a/src/app/api/incidents/[id]/summary/route.ts
+++ b/src/app/api/incidents/[id]/summary/route.ts
@@ -4,6 +4,8 @@ import { createErrorResponse, notFoundError, successResponse, validationError } 
 import { requireUser } from '@/lib/session';
 import { generateIncidentSummary } from '@/lib/ai/incident-summary';
 import { recordAudit } from '@/lib/audit';
+import { enforceRateLimit } from '@/lib/errors';
+import { RATE_LIMITS } from '@/lib/rate-limit';
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -21,6 +23,9 @@ export async function POST(request: NextRequest, { params }: Params) {
     logRequest('POST', '/api/incidents/[id]/summary');
     const guard = await requireUser();
     if (!guard.ok) return guard.response;
+
+    const limited = enforceRateLimit(`summary:${guard.user.id}`, RATE_LIMITS.CHAT);
+    if (limited) return limited;
 
     const { id } = await params;
     const result = await generateIncidentSummary(id, guard.user);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { Prisma } from '@/generated/prisma';
 import { logError } from './logger';
+import { checkRateLimit } from './rate-limit';
 
 /**
  * Error Handling Utilities
@@ -288,6 +289,30 @@ export function rateLimitError(): NextResponse {
     } as ApiError,
     { status: 429 }
   );
+}
+
+/**
+ * Handler-side rate-limit guard. Returns a 429 to return, or null to continue.
+ *
+ * Lives here rather than in `rate-limit.ts` because `middleware.ts` imports the
+ * counter, and middleware runs on the Edge runtime: pulling this file in would
+ * drag Prisma into that bundle and fail the build. The counter stays pure; the
+ * response shape stays with the other response helpers. (SEC-23)
+ *
+ * Keyed by user id rather than address, because these routes are authenticated
+ * and the thing being bounded is what one account can spend. A school's shared
+ * NAT would otherwise put every administrator in the building on one counter.
+ */
+export function enforceRateLimit(
+  key: string,
+  { limit, windowMs }: { limit: number; windowMs: number }
+): NextResponse | null {
+  const result = checkRateLimit(key, limit, windowMs);
+  if (result.allowed) return null;
+
+  const response = rateLimitError();
+  response.headers.set('Retry-After', String(result.retryAfterSeconds));
+  return response;
 }
 
 /**

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { checkRateLimit, resetRateLimits, RATE_LIMITS } from './rate-limit';
+
+describe('checkRateLimit', () => {
+  beforeEach(() => resetRateLimits());
+
+  const NOW = 1_000_000;
+
+  it('allows up to the limit and refuses the one after', () => {
+    for (let i = 1; i <= 3; i++) {
+      expect(checkRateLimit('k', 3, 60_000, NOW).allowed).toBe(true);
+    }
+    expect(checkRateLimit('k', 3, 60_000, NOW).allowed).toBe(false);
+  });
+
+  it('counts each key separately', () => {
+    // Otherwise one noisy caller locks out every administrator.
+    expect(checkRateLimit('a', 1, 60_000, NOW).allowed).toBe(true);
+    expect(checkRateLimit('b', 1, 60_000, NOW).allowed).toBe(true);
+    expect(checkRateLimit('a', 1, 60_000, NOW).allowed).toBe(false);
+  });
+
+  it('opens a fresh window once the old one expires', () => {
+    expect(checkRateLimit('k', 1, 60_000, NOW).allowed).toBe(true);
+    expect(checkRateLimit('k', 1, 60_000, NOW + 59_000).allowed).toBe(false);
+    expect(checkRateLimit('k', 1, 60_000, NOW + 60_001).allowed).toBe(true);
+  });
+
+  it('reports what a Retry-After header needs', () => {
+    const first = checkRateLimit('k', 1, 60_000, NOW);
+    expect(first.resetAt).toBe(NOW + 60_000);
+
+    const refused = checkRateLimit('k', 1, 60_000, NOW + 30_000);
+    expect(refused.allowed).toBe(false);
+    expect(refused.retryAfterSeconds).toBe(30);
+    // Never zero: a Retry-After of 0 invites an immediate retry.
+    expect(checkRateLimit('k', 1, 60_000, NOW + 59_999).retryAfterSeconds).toBe(1);
+  });
+
+  it('reports remaining without going negative', () => {
+    expect(checkRateLimit('k', 2, 60_000, NOW).remaining).toBe(1);
+    expect(checkRateLimit('k', 2, 60_000, NOW).remaining).toBe(0);
+    expect(checkRateLimit('k', 2, 60_000, NOW).remaining).toBe(0);
+  });
+
+  it('does not accumulate windows for keys that have expired', () => {
+    // Keyed by IP for unauthenticated traffic, so an attacker cycling source
+    // addresses would otherwise turn the limiter into a memory leak.
+    for (let i = 0; i < 500; i++) checkRateLimit(`ip-${i}`, 5, 1_000, NOW);
+    // Eviction runs at most once a minute; step past both that and the window.
+    checkRateLimit('trigger', 5, 1_000, NOW + 120_000);
+    // The old keys are gone, so each starts a fresh window.
+    expect(checkRateLimit('ip-0', 1, 1_000, NOW + 120_000).allowed).toBe(true);
+  });
+
+  it('sets sign-in stricter than chat, because it is the unauthenticated one', () => {
+    // /api/auth/* is public and bcrypt at cost 12 blocks the event loop for
+    // ~0.25s per attempt, even for an address with no account.
+    const signInPerMinute = RATE_LIMITS.SIGN_IN.limit / (RATE_LIMITS.SIGN_IN.windowMs / 60_000);
+    const chatPerMinute = RATE_LIMITS.CHAT.limit / (RATE_LIMITS.CHAT.windowMs / 60_000);
+    expect(signInPerMinute).toBeLessThan(chatPerMinute);
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,106 @@
+/**
+ * A fixed-window request counter, held in this process's memory.
+ *
+ * Deliberately simple, and deliberately not distributed. The pilot runs one
+ * replica (`minReplicas: 1` / `maxReplicas: 1` in the Container Apps config),
+ * so one process sees every request and an in-memory counter is exact. Reaching
+ * for Redis before there is a second replica would add an operational
+ * dependency, and a failure mode, to buy nothing.
+ *
+ * **This must move to a shared store before a second replica exists.** With N
+ * replicas each holds its own counter, so the effective limit becomes N times
+ * what is configured -- it degrades quietly rather than failing, which is
+ * exactly the kind of thing that goes unnoticed. `docs/roadmap.md` records it.
+ *
+ * Fixed window, not sliding: a caller can send `limit` requests at the end of
+ * one window and `limit` again at the start of the next. That burst is
+ * acceptable here because the purpose is to bound sustained abuse -- unbounded
+ * password guessing, and unbounded billed model calls -- not to smooth traffic.
+ * (SEC-11, SEC-23)
+ */
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Requests still permitted in the current window. */
+  remaining: number;
+  /** When the current window ends, epoch ms. */
+  resetAt: number;
+  /** Seconds until the window ends; what a Retry-After header should say. */
+  retryAfterSeconds: number;
+}
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const windows = new Map<string, Window>();
+
+/**
+ * Drop expired windows so the map cannot grow without bound.
+ *
+ * Keyed by IP for unauthenticated traffic, so without this an attacker cycling
+ * source addresses turns the limiter into a memory leak -- a denial of service
+ * introduced by the thing meant to prevent one.
+ */
+function evictExpired(now: number): void {
+  for (const [key, window] of windows) {
+    if (window.resetAt <= now) windows.delete(key);
+  }
+}
+
+let lastEviction = 0;
+const EVICTION_INTERVAL_MS = 60_000;
+
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number,
+  now: number = Date.now()
+): RateLimitResult {
+  if (now - lastEviction > EVICTION_INTERVAL_MS) {
+    evictExpired(now);
+    lastEviction = now;
+  }
+
+  const existing = windows.get(key);
+  const window =
+    existing && existing.resetAt > now ? existing : { count: 0, resetAt: now + windowMs };
+
+  window.count += 1;
+  windows.set(key, window);
+
+  const allowed = window.count <= limit;
+  return {
+    allowed,
+    remaining: Math.max(0, limit - window.count),
+    resetAt: window.resetAt,
+    retryAfterSeconds: Math.max(1, Math.ceil((window.resetAt - now) / 1000)),
+  };
+}
+
+/** Test seam. Never called in production code. */
+export function resetRateLimits(): void {
+  windows.clear();
+  lastEviction = 0;
+}
+
+/**
+ * Limits, and why each is what it is.
+ *
+ * SIGN_IN is the one that matters most: `/api/auth/*` is public, and
+ * `src/auth.ts` runs `bcrypt.compare` at cost 12 even for an address with no
+ * account, so every attempt costs roughly a quarter-second of *blocking* CPU on
+ * a single event loop. A few hundred a minute make the app unavailable to every
+ * administrator while also giving unbounded password guessing.
+ *
+ * CHAT bounds billed spend: one chat turn can trigger classification,
+ * obligation derivation and the guidance call. 30/minute is far above what an
+ * administrator typing into a chat box can produce and far below what a loop
+ * can.
+ */
+export const RATE_LIMITS = {
+  SIGN_IN: { limit: 10, windowMs: 5 * 60_000 },
+  CHAT: { limit: 30, windowMs: 60_000 },
+  UPLOAD: { limit: 20, windowMs: 60_000 },
+} as const;


### PR DESCRIPTION
Open since the first audit. `rateLimitError()` has been exported and imported
by nothing this whole time.

## Why sign-in is the one that matters

`/api/auth/*` is public, and `src/auth.ts` runs `bcrypt.compare` at cost 12
**deliberately even for an address with no account** (so timing doesn't reveal
whether one exists). Every attempt therefore costs ~0.25s of *blocking* CPU on
a single event loop. A few hundred a minute made the app unavailable to every
administrator, while password guessing was unbounded at the same time.

Limited by client address in `middleware.ts` — it's NextAuth's own route, so
there's no handler of ours to put it in. Chat, summaries and uploads are
limited by **user id** in their handlers: the bound there is on what one
account can spend, and keying by address would put every administrator behind a
school's shared NAT on one counter.

## Two things worth knowing

**`src/lib/rate-limit.ts` imports nothing, deliberately.** `middleware.ts` runs
on the Edge runtime, and my first version had the counter import `errors.ts`
for the 429 helper — which pulled Prisma into the middleware bundle and failed
the build. The counter is pure; the response helper stays with the other
response helpers, which only handlers import.

**The window map evicts expired entries.** Without that, an attacker cycling
source addresses turns the limiter into a memory leak — a denial of service
introduced by the thing meant to prevent one.

## The limitation, stated plainly

The counters are in this process's memory. **Exact at one replica** (what the
Container Apps config pins), **wrong at more than one** — with N replicas the
effective limit becomes N times what's configured. It degrades quietly rather
than failing, which is exactly the kind of thing that goes unnoticed, so README
and the roadmap both say to move it to a shared store *before* raising
`maxReplicas`.

Fixed window rather than sliding, so a caller can burst across a boundary.
Acceptable: the purpose is bounding sustained abuse, not smoothing traffic.

## Tests

Seven unit tests, plus an e2e that floods the sign-in endpoint and asserts a
429 with a `Retry-After` that leaks nothing about whether the account exists.
Verified by disabling the limiter — the test fails with `last status 302`.

| | |
|---|---|
| typecheck | 0 errors |
| lint | 0 errors, 3 pre-existing warnings |
| build | clean |
| unit | **138** |
| e2e | **57** |