### PR TITLE
SEC-10: bound an upload body before it is parsed, not after

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ is meant to change; `docs/audit/` and `docs/history/` are dated records that
 should not be rewritten. This repo previously accumulated four status files that
 all drifted out of date, so keep this one current or delete it.
 
-Last reviewed: 2026-09-01. Context: entering a single-user pilot.
+Last reviewed: 2026-09-02. Context: entering a single-user pilot.
 
 ---
 
@@ -154,9 +154,10 @@ All 11 JICK sections (A–K) parse, 9 of them carrying their RSA reference.
 
 ---
 
-### Audit 2026-09-01 — **done, with one blocker deferred**
+### Audit 2026-09-01 — **done; all six blockers now closed**
 
-Six parallel read-only passes; 142 findings, 6 blockers. Five fixed. See
+Six parallel read-only passes; 142 findings, 6 blockers. Five fixed at the time,
+the sixth on 2026-09-02. See
 [`docs/audit/2026-09-01-findings.md`](./audit/2026-09-01-findings.md) and
 [`-work-completed.md`](./audit/2026-09-01-work-completed.md).
 
@@ -168,11 +169,11 @@ New Hampshire law. Until that is fixed, every countdown in the product is the
 model's guess, and `ComplianceAction` has no `policyId` to reconcile it
 against.
 
-The fix needs a product decision first — **OQ-5: what should the product do
+The fix needed a product decision first — **OQ-5: what should the product do
 when the library cannot support a deadline?** Suppress the obligation, show it
-without a countdown, or show it marked unverified. Settle that and the
-two-phase re-classification is straightforward. The UI has been corrected in
-the meantime so it no longer claims the deadline came from the policy.
+without a countdown, or show it marked unverified. **Decided and shipped
+2026-09-02**; the blocker is closed and the decision is recorded below. All six
+are now fixed.
 
 Three other things that were true and are no longer:
 
@@ -334,6 +335,37 @@ verified to fail when the limiter is removed.
 
 ---
 
+### ~~Upload memory bound (SEC-10)~~ — **done 2026-09-02**
+
+Both upload routes called `request.formData()` and *then* checked `file.size`,
+under a comment saying the check ran "before buffering the body". It did not.
+`formData()` reads the whole request into memory to parse it, so the size limit
+rejected an oversized file only after the process had already paid for it. The
+limit was accurate and bought nothing: a few concurrent multi-hundred-megabyte
+POSTs from one signed-in account could take the process down, which at the one
+replica Container Apps pins is every administrator.
+
+`readCappedFormData` in `src/lib/uploads.ts` now reads both bodies under a hard
+ceiling of the file limit plus a 64KB multipart envelope. Content-Length is
+checked first because it is free and rejects the honest case without reading a
+byte, but it is not sufficient on its own — it is absent under chunked transfer
+encoding and it can simply lie — so the body also goes through a counter that
+errors the stream the moment the ceiling is passed. Erroring is what makes it a
+bound rather than a measurement: the parser stops and we stop reading the
+socket.
+
+`assertWithinSizeLimit` stays, and its comment has been corrected to say what it
+actually is: the exact per-file limit, enforced once the part is parsed. The two
+do different jobs and the old comment claimed the second did the first's.
+
+Nine unit tests. The one that matters asserts the property the change exists
+for — a body offering 12MB and a body offering 1.2GB, both declaring 512 bytes,
+are read to exactly the same bounded point — so what a request costs is decided
+by the ceiling and not by the client. Verified to fail: removing the counting
+stream fails three, removing the Content-Length check fails one.
+
+---
+
 ## Next — gated on real use
 
 ### 6. Run a real incident end to end, and watch it — *maintainer*
@@ -343,24 +375,27 @@ than another week of building against assumptions, and the two most uncertain
 design questions — how reliably obligations can be attributed to a policy, and
 whether chat is the right intake at all — are exactly what it will answer.
 
-### 7. Link obligations to their source policy — *~half a day*
+### ~~7. Link obligations to their source policy~~ — **done 2026-09-02, by OQ-5**
 
-An administrator currently sees *"Notify the superintendent — in 3h 18m"* with
-no authority attached and no way to verify it. The whole proposition is *here is
-your obligation and here is the law behind it*.
+Everything this step asked for arrived with OQ-5 rather than after step 6:
+`policyId`, `citation` and `deadlineSource` on `ComplianceAction`, obligations
+derived in a second pass with the retrieved excerpts in hand, and
+`resolveProvenance` attributing each one to a numbered excerpt that was actually
+supplied. `ObligationRow` renders the `AuthorityChip` and the citation, which it
+could always do — the data had simply never existed.
 
-`AuthorityChip` is built and renders a citation the moment one exists. Needs
-`policyId` + `citation` on `ComplianceAction`, and the classifier attributing
-each action to one of the retrieved policies.
+It landed early because it is the same schema change: deciding what to do about
+a deadline with no policy behind it *requires* the row to be able to name the
+policy behind it. The sequencing argument was not wrong, it was answered — the
+citation is best-effort, because the alternative is dropping obligations.
 
-Step 5a makes this materially better than it would have been: an obligation can
-now cite the provision it came from rather than the policy, so the chip can read
-`JICK §D` instead of `Policy JICK`. The section label is already on the chunk
-the guidance was drawn from, so attribution has something precise to attach to.
-
-Deliberately after step 6: watching which obligations come back attributable
-decides whether the citation is a required field or best-effort. Building it
-blind risks designing for attribution that does not hold up.
+The half deliberately still waiting on step 6 is the harder one, restated here
+so it is not read as finished: attribution verifies that the excerpt exists and
+was supplied, **not** that the excerpt states the deadline the model attributed
+to it. A model citing a real provision for a number that provision does not
+contain still produces a `policy`-sourced row. Closing that means parsing the
+deadline out of the provision text, and that wants real incidents to calibrate
+against.
 
 ---
 
@@ -370,8 +405,8 @@ blind risks designing for attribution that does not hold up.
 
 | Item | Why it can wait, and why it can't wait forever |
 |---|---|
-| Rate limiting (SEC-11) | Irrelevant at one user; one signed-in account can still run up the Anthropic bill |
-| Upload OOM (SEC-10, partial) | Size limits reject oversized files, but `request.formData()` buffers the body first, so a large POST still lands in memory |
+| ~~Rate limiting (SEC-11, SEC-23)~~ | **Done 2026-09-02.** It turned out not to be a can-wait item: sign-in ran bcrypt at cost 12 even for an address with no account, so a few hundred attempts a minute made the app unavailable to every administrator. Sign-in is limited by address in `middleware.ts`, chat and uploads by user id. The counters are per-process, so they must move to a shared store before `maxReplicas` is raised |
+| ~~Upload OOM (SEC-10)~~ | **Done 2026-09-02.** `readCappedFormData` bounds both upload bodies before they are parsed, by Content-Length and then by a counting stream that errors past the ceiling. Recorded above |
 | DNS rebinding (SEC-4, partial) | Needs a hostname allowlist, which is a decision about permitted policy sources |
 | ~~Unit tests~~ | **Done 2026-09-01.** Vitest, 79 tests over the pure logic: `describeDeadline`, `splitIntoChunks`, `cleanText`, `buildCoverageReport`, the upload path guards, the zod schemas, and the incident→category mapping. `npm run test:unit` runs in under a second; `npm test` runs unit then e2e, and CI runs unit before installing a browser. Writing them found three real bugs — see the audit record |
 

--- a/src/app/api/admin/policies/upload/route.ts
+++ b/src/app/api/admin/policies/upload/route.ts
@@ -10,6 +10,7 @@ import {
   assertIndexablePolicyText,
   assertWithinSizeLimit,
   maxUploadBytes,
+  readCappedFormData,
   safeUploadPath,
   UploadError,
   uploadErrorStatus,
@@ -36,7 +37,10 @@ export async function POST(request: NextRequest) {
     const limited = enforceRateLimit(`policy-upload:${guard.user.id}`, RATE_LIMITS.UPLOAD);
     if (limited) return limited;
 
-    const formData = await request.formData();
+    // Capped read, not `request.formData()`: the body is bounded before it is
+    // parsed, so an oversized POST costs the ceiling and not its own size.
+    // (SEC-10)
+    const formData = await readCappedFormData(request);
     const file = formData.get('file') as File | null;
     const url = formData.get('url') as string | null;
     const title = formData.get('title') as string;

--- a/src/app/api/attachments/upload/route.ts
+++ b/src/app/api/attachments/upload/route.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'fs';
 import {
   assertAllowedExtension,
   assertWithinSizeLimit,
+  readCappedFormData,
   safeUploadPath,
   UploadError,
   attachmentUploadsDir,
@@ -31,7 +32,10 @@ export async function POST(request: NextRequest) {
     const limited = enforceRateLimit(`upload:${guard.user.id}`, RATE_LIMITS.UPLOAD);
     if (limited) return limited;
 
-    const formData = await request.formData();
+    // Capped read, not `request.formData()`: the body is bounded before it is
+    // parsed, so an oversized POST costs the ceiling and not its own size.
+    // (SEC-10)
+    const formData = await readCappedFormData(request);
     const file = formData.get('file') as File;
     const incidentId = formData.get('incidentId') as string;
 
@@ -54,7 +58,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Validate type and size before buffering the body. (SEC-5, SEC-10)
+    // Type, then the exact per-file limit. The memory bound was applied by
+    // readCappedFormData above; this is the limit itself. (SEC-5, SEC-10)
     const ext = assertAllowedExtension(file.name, ALLOWED_ATTACHMENT_EXTENSIONS);
     assertWithinSizeLimit(file);
 

--- a/src/lib/uploads.test.ts
+++ b/src/lib/uploads.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolve, sep } from 'path';
 import {
   assertAllowedExtension,
@@ -9,6 +9,7 @@ import {
   assertWithinSizeLimit,
   DEFAULT_MAX_UPLOAD_BYTES,
   fileExtension,
+  readCappedFormData,
   safeUploadPath,
   UploadError,
 } from './uploads';
@@ -183,5 +184,140 @@ describe('uploads directory resolution', () => {
     for (const dir of [policyUploadsDir(), attachmentUploadsDir()]) {
       expect(dir.startsWith(uploadsRoot() + sep)).toBe(true);
     }
+  });
+});
+
+describe('readCappedFormData', () => {
+  // The hole this closes: both upload routes called `request.formData()` and
+  // then checked `file.size`. The check was accurate and useless -- parsing had
+  // already read the whole body into memory. Size limits rejected the file; the
+  // memory was spent either way. (SEC-10)
+
+  const original = process.env.MAX_FILE_SIZE;
+
+  // Small enough that a test can exceed it in a few kilobytes, so these run in
+  // milliseconds rather than allocating tens of megabytes.
+  const LIMIT = 4096;
+  const OVERHEAD = 64 * 1024;
+  const CEILING = LIMIT + OVERHEAD;
+  const CHUNK = 64 * 1024;
+
+  beforeEach(() => {
+    process.env.MAX_FILE_SIZE = String(LIMIT);
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.MAX_FILE_SIZE;
+    else process.env.MAX_FILE_SIZE = original;
+  });
+
+  /** A real multipart body, built the way the browser builds one. */
+  async function multipart(fileBytes: number) {
+    const form = new FormData();
+    form.set('incidentId', 'inc-1');
+    form.set('file', new File([new Uint8Array(fileBytes)], 'statement.pdf'));
+    const encoded = new Request('http://x/upload', { method: 'POST', body: form });
+    return {
+      headers: encoded.headers,
+      body: encoded.body,
+    };
+  }
+
+  /**
+   * A body that keeps producing megabytes and reports how many it got to emit.
+   * `declaredLength` is what the request *claims*, which is not necessarily
+   * what it sends -- an attacker controls both independently.
+   */
+  function endlessBody(chunks: number, declaredLength?: number) {
+    const emitted = { chunks: 0 };
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          if (emitted.chunks >= chunks) {
+            controller.close();
+            return;
+          }
+          emitted.chunks += 1;
+          controller.enqueue(new Uint8Array(CHUNK));
+        },
+      },
+      // highWaterMark 0 so the stream produces nothing until it is read from.
+      // At the default of 1 it eagerly fills a chunk on construction, and
+      // `emitted` would then count a byte nobody asked for.
+      { highWaterMark: 0 }
+    );
+    const headers = new Headers({
+      'content-type': 'multipart/form-data; boundary=----x',
+    });
+    if (declaredLength !== undefined) {
+      headers.set('content-length', String(declaredLength));
+    }
+    return { request: { headers, body }, emitted };
+  }
+
+  it('reads a body that fits, and returns its fields', async () => {
+    const form = await readCappedFormData(await multipart(1024));
+    expect(form.get('incidentId')).toBe('inc-1');
+    expect((form.get('file') as File).size).toBe(1024);
+  });
+
+  it('rejects a declared Content-Length over the ceiling with a 413', async () => {
+    const { request, emitted } = endlessBody(1000, CEILING + 1);
+    await expect(readCappedFormData(request)).rejects.toMatchObject({
+      status: 413,
+    });
+    // Rejected on the header alone: not one byte of the body was read.
+    expect(emitted.chunks).toBe(0);
+  });
+
+  it('rejects a body that exceeds the ceiling while declaring nothing', async () => {
+    // Chunked transfer encoding sends no Content-Length, so the header check
+    // cannot see this one coming. Only the counting stream can.
+    const { request } = endlessBody(1000);
+    await expect(readCappedFormData(request)).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+
+  it('rejects a body that exceeds the ceiling while declaring it is small', async () => {
+    const { request } = endlessBody(1000, 512);
+    await expect(readCappedFormData(request)).rejects.toMatchObject({
+      status: 413,
+    });
+  });
+
+  /**
+   * The property the whole change exists for, and the one the old code did not
+   * have: what a request costs the process is decided by the ceiling, not by
+   * the client. A body claiming 512 bytes and sending 64MB must be stopped
+   * mid-flight, so how much gets read cannot depend on how much is offered.
+   */
+  it('reads the same bounded amount however much the body offers', async () => {
+    const small = endlessBody(200, 512); //  12MB on offer
+    const huge = endlessBody(20_000, 512); // 1.2GB on offer
+
+    await expect(readCappedFormData(small.request)).rejects.toMatchObject({ status: 413 });
+    await expect(readCappedFormData(huge.request)).rejects.toMatchObject({ status: 413 });
+
+    expect(huge.emitted.chunks).toBe(small.emitted.chunks);
+    // The ceiling plus the pipeline's own in-flight buffering -- a fixed
+    // overhead of a chunk or two, not a function of the 1.2GB offered.
+    expect(huge.emitted.chunks * CHUNK).toBeLessThan(CEILING + 4 * CHUNK);
+  });
+
+  it('rejects a request with no body at all', async () => {
+    const request = {
+      headers: new Headers({ 'content-type': 'multipart/form-data; boundary=--x' }),
+      body: null,
+    };
+    await expect(readCappedFormData(request)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('reports a malformed body as a 400, not a 500', async () => {
+    const request = {
+      headers: new Headers({ 'content-type': 'multipart/form-data; boundary=----x' }),
+      body: new Response('not multipart at all').body,
+    };
+    await expect(readCappedFormData(request)).rejects.toMatchObject({ status: 400 });
   });
 });

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -41,9 +41,13 @@ export function fileExtension(originalName: string): string {
 }
 
 /**
- * Rejects before the body is buffered into memory. `file.size` is set by
- * the runtime from the multipart part, so this does not require reading
- * the file first.
+ * The exact per-file limit, checked once the part is in hand.
+ *
+ * This does NOT bound memory on its own: `file.size` is only known after the
+ * multipart body has been parsed, and parsing buffers it. Reaching this
+ * function at all means the bytes were already read. `readCappedFormData` is
+ * what stops an oversized body before that happens; this is what enforces the
+ * limit precisely afterwards. (SEC-10)
  */
 export function assertWithinSizeLimit(file: File): void {
   const limit = maxUploadBytes();
@@ -52,6 +56,82 @@ export function assertWithinSizeLimit(file: File): void {
       `File exceeds the ${Math.floor(limit / (1024 * 1024))}MB upload limit`,
       413
     );
+  }
+}
+
+/**
+ * The multipart envelope around the file: boundary lines, per-part headers,
+ * and the handful of small text fields that travel with it (`incidentId`, or
+ * a policy's title and facets). Generous on purpose -- the ceiling here only
+ * has to bound memory, and `assertWithinSizeLimit` enforces the real limit on
+ * the file itself once it has been parsed.
+ */
+const MULTIPART_OVERHEAD_BYTES = 64 * 1024;
+
+/** What `readCappedFormData` needs of a Request. Both routes pass a NextRequest. */
+interface MultipartRequest {
+  headers: Headers;
+  body: ReadableStream<Uint8Array> | null;
+}
+
+/**
+ * Reads a multipart body under a hard byte ceiling.
+ *
+ * Both upload routes called `request.formData()` and then checked `file.size`,
+ * with a comment claiming the check ran "before buffering the body". It did
+ * not: `formData()` reads the whole request into memory first, so the size
+ * limit rejected an oversized file only after paying for it. A few concurrent
+ * multi-hundred-megabyte POSTs from one signed-in account were enough to take
+ * the process down, which on a single-replica deployment is every
+ * administrator. (SEC-10)
+ *
+ * Content-Length is checked first because it is free and rejects the honest
+ * case without reading a byte. It is not sufficient on its own -- it is absent
+ * under chunked transfer encoding and it can simply lie -- so the body is also
+ * piped through a counter that errors the moment the ceiling is passed. The
+ * bound then holds regardless of what the header claimed, and the parser never
+ * sees more than the ceiling.
+ */
+export async function readCappedFormData(request: MultipartRequest): Promise<FormData> {
+  const limit = maxUploadBytes();
+  const ceiling = limit + MULTIPART_OVERHEAD_BYTES;
+  const tooLarge = () =>
+    new UploadError(
+      `Upload exceeds the ${Math.floor(limit / (1024 * 1024))}MB limit`,
+      413
+    );
+
+  const declared = Number(request.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > ceiling) throw tooLarge();
+
+  const body = request.body;
+  if (!body) throw new UploadError('Expected a multipart upload body', 400);
+
+  let seen = 0;
+  let exceeded = false;
+  const counter = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      seen += chunk.byteLength;
+      if (seen > ceiling) {
+        // Erroring the stream is what makes this a bound rather than a
+        // measurement: the parser stops, and we stop reading the socket.
+        exceeded = true;
+        controller.error(tooLarge());
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+
+  try {
+    return await new Response(body.pipeThrough(counter), {
+      headers: { 'content-type': request.headers.get('content-type') ?? '' },
+    }).formData();
+  } catch (error) {
+    // The parser wraps the stream's error, so the flag is what survives.
+    if (exceeded) throw tooLarge();
+    if (error instanceof UploadError) throw error;
+    throw new UploadError('Could not read the upload', 400);
   }
 }
 


### PR DESCRIPTION
## The hole

Both upload routes called `request.formData()` and *then* checked `file.size`, under a comment saying the check ran "before the body is buffered into memory". It did not. `formData()` reads the whole request in to parse it, so the size limit was accurate and bought nothing: an oversized file was rejected having already been paid for.

A few concurrent multi-hundred-megabyte POSTs from one signed-in account could take the process down — and at the one replica Container Apps pins, that is every administrator at once.

`assertWithinSizeLimit`'s comment claimed the job this PR adds, which is how the gap survived an audit that read it.

## The fix

`readCappedFormData` (`src/lib/uploads.ts`) reads both bodies under a ceiling of the file limit plus a 64KB multipart envelope:

- **Content-Length first** — free, and rejects the honest case without reading a byte.
- **Then a counting stream** — because Content-Length is absent under chunked transfer encoding and can simply lie. It errors the stream the moment the ceiling is passed. Erroring is what makes it a bound rather than a measurement: the parser stops and we stop reading the socket.

`assertWithinSizeLimit` stays and does the other half — the exact per-file limit, enforced once the part is parsed. Its comment now says that.

It takes a structural `{ headers, body }` rather than a `Request`. Both `NextRequest`s satisfy it, and it lets a test build a request that lies about its length without a `duplex` cast on `RequestInit`.

## Tests

Nine unit tests. The one the change exists for: a body offering 12MB and a body offering 1.2GB, both declaring 512 bytes, are read to *exactly the same* bounded point — what a request costs is decided by the ceiling, not by the client.

Verified to fail, per the repo's rule that a test must be able to:

| Guard removed | Tests that fail |
|---|---|
| the counting stream | 3 |
| the Content-Length check | 1 |

All four gates: `typecheck` clean, `lint` 0 errors (3 pre-existing warnings in `scripts/`), `build` clean, 151 unit + 59 e2e passing.

## Roadmap, brought current

Three entries were describing work that has landed:

- **Step 7** (link obligations to their source policy) was delivered by OQ-5 rather than after step 6, because it is the same schema change — deciding what to do about a deadline with no policy behind it requires the row to be able to name the policy behind it. The half still waiting on step 6 is restated so it is not read as finished: attribution proves the excerpt was *supplied*, not that it *states* the deadline attributed to it.
- The **hardening table** still listed rate limiting and this OOM as pending.
- The **audit section** still said one of six blockers was open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)