### PR TITLE
Migrate off the retired model, and fix what that was hiding

### DIFF
--- a/e2e/support/claude-stub.ts
+++ b/e2e/support/claude-stub.ts
@@ -111,8 +111,17 @@ export function startClaudeStub(port: number): Promise<Server> {
           id: 'msg_stub',
           type: 'message',
           role: 'assistant',
-          model: 'claude-sonnet-4-20250514',
-          content: [{ type: 'text', text }],
+          model: 'claude-sonnet-5',
+          // A thinking block ahead of the text, because that is the shape the
+          // real API returns. The stub used to reply with a lone text block, so
+          // the suite passed while production read `content[0]`, found a
+          // thinking block, and stored an empty string as the assistant's
+          // answer. A stub that is easier to parse than the real thing tests
+          // the wrong system.
+          content: [
+            { type: 'thinking', thinking: '', signature: 'stub' },
+            { type: 'text', text },
+          ],
           stop_reason: 'end_turn',
           usage: { input_tokens: 120, output_tokens: 60 },
         })

--- a/scripts/test-claude.ts
+++ b/scripts/test-claude.ts
@@ -25,10 +25,11 @@ async function testClaude() {
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
 
-    console.log('📡 Sending test request to Claude 3.5 Sonnet...\n');
+    const model = process.env.ANTHROPIC_MODEL || 'claude-sonnet-5';
+    console.log(`📡 Sending test request to ${model}...\n`);
 
     const message = await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model,
       max_tokens: 150,
       messages: [
         {

--- a/src/app/incidents/[id]/page.tsx
+++ b/src/app/incidents/[id]/page.tsx
@@ -415,6 +415,12 @@ const KIND_TONE: Record<TimelineEvent['kind'], string> = {
 function TimelineRow({ event }: { event: TimelineEvent }) {
   const mounted = useMounted();
   const isAttachment = event.kind === 'attachment';
+  // Guidance and summaries are markdown -- the prompt asks the model for
+  // `## headers` and bold, and the timeline was rendering the literal
+  // characters, which is the bug GuidanceBlock was written for and this view
+  // never picked up. The reporter's own words stay plain text: they are user
+  // input, not markup, and must not be reinterpreted as formatting.
+  const isModelOutput = event.kind === 'exchange' && event.meta !== 'user';
   return (
     <div className="flex gap-3 rounded-[12px] border border-line bg-surface px-4 py-3">
       <span className={`mt-2 h-2 w-2 flex-none rounded-full ${KIND_TONE[event.kind]}`} aria-hidden />
@@ -446,6 +452,8 @@ function TimelineRow({ event }: { event: TimelineEvent }) {
             >
               {event.body}
             </a>
+          ) : isModelOutput ? (
+            <GuidanceBlock>{event.body}</GuidanceBlock>
           ) : (
             <p className="whitespace-pre-wrap text-[14px] leading-[1.6] text-text-tertiary">
               {event.body}

--- a/src/components/design/ObligationRow.tsx
+++ b/src/components/design/ObligationRow.tsx
@@ -50,53 +50,60 @@ export function ObligationRow({
   };
 
   return (
-    <div className="flex flex-col gap-3 border-b border-input px-5 py-[18px] last:border-b-0 sm:flex-row sm:gap-[18px]">
-      <DeadlineClock
-        dueDate={obligation.dueDate}
-        status={obligation.status}
-        completedAt={obligation.completedAt}
-        verified={obligation.deadlineSource !== 'model'}
-      />
+    // Container query, not `sm:`. The same row renders in the wide queue on the
+    // home page and in the 340px aside on an incident -- and a viewport
+    // breakpoint cannot tell those apart, so at any desktop width the aside got
+    // the three-column row layout and squeezed the description to one word per
+    // line. `@sm` (24rem) measures the space the row actually has.
+    <div className="@container border-b border-input last:border-b-0">
+      <div className="flex flex-col gap-3 px-5 py-[18px] @sm:flex-row @sm:gap-[18px]">
+        <DeadlineClock
+          dueDate={obligation.dueDate}
+          status={obligation.status}
+          completedAt={obligation.completedAt}
+          verified={obligation.deadlineSource !== 'model'}
+        />
 
-      <div className="flex flex-1 flex-col gap-1.5">
-        <span
-          className={`text-[16px] font-medium leading-[1.4] ${
-            done ? 'text-text-muted line-through' : 'text-text'
-          }`}
-        >
-          {obligation.description || obligation.actionType}
-        </span>
-
-        {obligation.incidentTitle && showIncident && (
-          <span className="text-[12px] text-text-muted">{obligation.incidentTitle}</span>
-        )}
-
-        {obligation.deadlineSource === 'model' && !done && (
-          <span className="text-[12px] leading-[1.4] text-text-muted">
-            Deadline not found in the loaded policy — confirm it before acting.
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <span
+            className={`text-[16px] font-medium leading-[1.4] ${
+              done ? 'text-text-muted line-through' : 'text-text'
+            }`}
+          >
+            {obligation.description || obligation.actionType}
           </span>
-        )}
 
-        {(obligation.jurisdiction || obligation.citation) && (
-          <div className="flex items-center gap-2">
-            {obligation.jurisdiction && <AuthorityChip jurisdiction={obligation.jurisdiction} />}
-            {obligation.citation && (
-              <span className="text-[12px] text-text-muted">{obligation.citation}</span>
-            )}
-          </div>
+          {obligation.incidentTitle && showIncident && (
+            <span className="text-[12px] text-text-muted">{obligation.incidentTitle}</span>
+          )}
+
+          {obligation.deadlineSource === 'model' && !done && (
+            <span className="text-[12px] leading-[1.4] text-text-muted">
+              Deadline not found in the loaded policy — confirm it before acting.
+            </span>
+          )}
+
+          {(obligation.jurisdiction || obligation.citation) && (
+            <div className="flex items-center gap-2">
+              {obligation.jurisdiction && <AuthorityChip jurisdiction={obligation.jurisdiction} />}
+              {obligation.citation && (
+                <span className="text-[12px] text-text-muted">{obligation.citation}</span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {onDone && !done && (
+          <button
+            type="button"
+            onClick={handleDone}
+            disabled={busy}
+            className="inline-flex min-h-[44px] flex-none items-center self-start rounded-[12px] bg-text px-[14px] text-[13px] font-medium text-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {busy ? 'Saving…' : 'Mark done'}
+          </button>
         )}
       </div>
-
-      {onDone && !done && (
-        <button
-          type="button"
-          onClick={handleDone}
-          disabled={busy}
-          className="inline-flex min-h-[44px] flex-none items-center self-start rounded-[12px] bg-text px-[14px] text-[13px] font-medium text-bg transition-opacity hover:opacity-90 disabled:opacity-50"
-        >
-          {busy ? 'Saving…' : 'Mark done'}
-        </button>
-      )}
     </div>
   );
 }

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -285,9 +285,15 @@ class ClaudeService {
   private maxTokens: number;
 
   constructor() {
-    // Using Claude 3.5 Sonnet (latest as of the code)
-    this.model = 'claude-sonnet-4-20250514';
-    this.maxTokens = 4096;
+    // Claude Sonnet 5. Override with ANTHROPIC_MODEL when a deployment needs to
+    // pin an older snapshot -- a retired id fails as a 404 not_found_error at
+    // request time, which surfaces to the administrator as a generic 503.
+    this.model = process.env.ANTHROPIC_MODEL || 'claude-sonnet-5';
+    // Extended thinking spends this same budget before any answer tokens are
+    // produced, so 4096 was no longer a 4096-token answer -- a long guidance
+    // reply could exhaust it mid-reasoning and come back with `max_tokens` and
+    // no text.
+    this.maxTokens = 16384;
   }
 
   /**
@@ -337,9 +343,19 @@ class ClaudeService {
   async generateResponse(
     messages: ClaudeMessage[],
     systemPrompt?: string,
+    // No temperature. It is deprecated on current models -- sending any value
+    // but the default is rejected outright as an invalid_request_error, which
+    // is what silently broke classification: every incident stayed
+    // `Unclassified` with zero obligations because the call never landed.
     options?: {
       maxTokens?: number;
-      temperature?: number;
+      /**
+       * Turn extended thinking off. Reasoning tokens are drawn from the same
+       * `max_tokens` budget as the answer, so a budget sized for a 6-word title
+       * can be spent entirely on thinking and return no text at all. Set this
+       * wherever the budget is tight and the task needs no deliberation.
+       */
+      thinking?: 'disabled';
     }
   ): Promise<ClaudeResponse> {
     const startTime = Date.now();
@@ -352,7 +368,9 @@ class ClaudeService {
       const response = await client.messages.create({
         model: this.model,
         max_tokens: options?.maxTokens || this.maxTokens,
-        temperature: options?.temperature || 1.0,
+        ...(options?.thinking === 'disabled'
+          ? { thinking: { type: 'disabled' as const } }
+          : {}),
         system: systemPrompt,
         messages: messages.map(msg => ({
           role: msg.role,
@@ -361,17 +379,31 @@ class ClaudeService {
       });
 
       const duration = Date.now() - startTime;
-      const textContent = response.content[0];
+      // The answer is the text blocks, not block zero. Current models put a
+      // `thinking` block first, so reading content[0] returned '' and the
+      // empty string was stored as an assistant turn and rendered as a blank
+      // answer -- a failed call made to look like guidance, which is the
+      // failure mode FLOW-7 exists to prevent.
+      const answer = response.content
+        .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+        .map(block => block.text)
+        .join('');
+      if (!answer) {
+        throw new Error(
+          `Claude returned no text content (stop_reason: ${response.stop_reason ?? 'unknown'})`
+        );
+      }
+
       const totalTokens = response.usage.input_tokens + response.usage.output_tokens;
 
-      // Approximate cost calculation (Claude 3.5 Sonnet pricing)
+      // Approximate cost calculation (Sonnet pricing)
       // $3 per million input tokens, $15 per million output tokens
       const cost = (response.usage.input_tokens * 0.000003) + (response.usage.output_tokens * 0.000015);
 
       logAIOperation('generateResponse', this.model, totalTokens, duration, cost);
 
       return {
-        content: textContent.type === 'text' ? textContent.text : '',
+        content: answer,
         usage: {
           inputTokens: response.usage.input_tokens,
           outputTokens: response.usage.output_tokens,
@@ -478,8 +510,7 @@ ${policyContext ? `\nRelevant Policies:\n${policyContext}` : ''}`;
           content: `Classify this incident:\n\n${incidentDescription}`,
         },
       ],
-      systemPrompt,
-      { temperature: 0.3 } // Lower temperature for more consistent classification
+      systemPrompt
     );
 
     try {
@@ -537,7 +568,7 @@ Example: ["Question 1?", "Question 2?", "Question 3?"]`;
     const response = await this.generateResponse(
       [{ role: 'user', content: userMessage }],
       systemPrompt,
-      { temperature: 0.5, maxTokens: 500 }
+      { maxTokens: 500, thinking: 'disabled' }
     );
 
     try {
@@ -609,7 +640,7 @@ ${policyContext}`;
     const response = await this.generateResponse(
       [{ role: 'user', content: request }],
       systemPrompt,
-      { temperature: 0.2, maxTokens: 1500 }
+      { maxTokens: 8192 }
     );
 
     try {
@@ -705,7 +736,7 @@ naming a policy, and say that none could be retrieved for this incident.${buildC
     const response = await this.generateResponse(
       [{ role: 'user', content: summaryRequest }],
       finalSystemPrompt,
-      { temperature: 0.3, maxTokens: 2048 }
+      { maxTokens: 8192 }
     );
 
     return response;
@@ -739,7 +770,7 @@ Examples:
       const response = await this.generateResponse(
         [{ role: 'user', content: firstMessage }],
         systemPrompt,
-        { temperature: 0.5, maxTokens: 50 }
+        { maxTokens: 50, thinking: 'disabled' }
       );
 
       // Clean up the response
@@ -779,7 +810,6 @@ Examples:
       const stream = await client.messages.create({
         model: this.model,
         max_tokens: this.maxTokens,
-        temperature: 1.0,
         system: systemPrompt,
         messages: messages.map(msg => ({
           role: msg.role,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,4 +1,5 @@
 import pino from 'pino';
+import pretty from 'pino-pretty';
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
@@ -13,26 +14,38 @@ const isDevelopment = process.env.NODE_ENV === 'development';
  * - debug (20): Debug information
  * - trace (10): Very detailed information
  */
-const logger = pino({
-  level: process.env.LOG_LEVEL || (isDevelopment ? 'debug' : 'info'),
-  transport: isDevelopment
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-          translateTime: 'HH:MM:ss.l',
-          ignore: 'pid,hostname',
-          singleLine: false,
-        },
-      }
-    : undefined,
-  formatters: {
-    level: (label) => {
-      return { level: label.toUpperCase() };
+/**
+ * pino-pretty is attached as a destination stream, not as a `transport`.
+ *
+ * A transport runs the formatter in a worker thread spawned by thread-stream,
+ * whose worker path the Next bundler rewrites to `/ROOT/node_modules/...`. That
+ * file does not exist, so the worker died on the first log line and every
+ * `logger.*` call after it threw `the worker has exited` -- as an
+ * uncaughtException, from inside request handlers. Logging an error was enough
+ * to bury the error being logged. A destination stream formats in-process and
+ * has no worker to lose.
+ */
+const destination = isDevelopment
+  ? pretty({
+      colorize: true,
+      translateTime: 'HH:MM:ss.l',
+      ignore: 'pid,hostname',
+      singleLine: false,
+    })
+  : undefined;
+
+const logger = pino(
+  {
+    level: process.env.LOG_LEVEL || (isDevelopment ? 'debug' : 'info'),
+    formatters: {
+      level: (label) => {
+        return { level: label.toUpperCase() };
+      },
     },
+    timestamp: pino.stdTimeFunctions.isoTime,
   },
-  timestamp: pino.stdTimeFunctions.isoTime,
-});
+  destination
+);
 
 /**
  * Create a child logger with additional context


### PR DESCRIPTION
The app could not answer a question. `claude-sonnet-4-20250514` is retired, so
every request 404'd and reached the administrator as a generic 503.

Migrating to Sonnet 5 exposed three further places where the code assumed an
older API contract. None of them failed loudly, and two of them silently
removed the tool's core output.

## What was broken

**The answer is not `content[0]`.** Current models emit a `thinking` block
first, so reading block zero yielded `''`. That empty string was written to
`Conversation` as an assistant turn and rendered as blank guidance behind an
HTTP 200 — a failed model call made indistinguishable from real advice, which
is the exact failure `FLOW-7` exists to prevent.

**`temperature` is deprecated.** Six call sites passed a non-default value and
each was rejected outright as an `invalid_request_error`. Classification was
among them, so incidents stayed `Unclassified` with zero obligations.

**Thinking tokens come out of `max_tokens`.** This one only appeared after the
first two were fixed: a long guidance reply could exhaust 4096 mid-reasoning
and return `stop_reason: max_tokens` with no text at all.

**The logger destroyed the errors it was asked to log.** `pino-pretty` as a
`transport` runs in a worker thread whose path the Next bundler rewrites to a
nonexistent `/ROOT/…`. The worker died on the first log line and every
`logger.*` call after it threw `the worker has exited` as an uncaughtException
from inside request handlers. Diagnosing the 503 above meant reading past a
thousand lines of worker stack traces to find one line of cause.

**Obligations were unreadable on an incident.** `ObligationRow` picked its
layout with `sm:`, a viewport breakpoint, but renders both in the wide queue on
`/` and in a 340px aside. At any desktop width both got the three-column row,
and the aside squeezed each description into a column one word wide.

**The timeline printed raw markdown.** `## headers` and `**bold**` shown as
their own source, in the fullest record of an incident.

## The fixes

| | |
|---|---|
| Model | `claude-sonnet-5`, overridable with `ANTHROPIC_MODEL` |
| Response parsing | join every text block; throw rather than store an empty answer |
| Temperature | removed, not worked around by pinning to an older snapshot |
| Token budgets | default 16384; judgement calls 8192; short mechanical calls keep tight budgets with thinking disabled |
| Logger | pino-pretty as a destination stream, formatting in-process |
| Obligations layout | container query — `@sm` measures the row's own width |
| Timeline | `GuidanceBlock`, on model output only |

Two decisions worth flagging for review:

- **Sonnet 5 with no temperature, rather than pinning to Sonnet 4.5.** Pinning
  would have preserved the deliberate `0.3` determinism on classification with
  a one-line change. Keeping a deprecated argument alive by freezing the model
  seemed the wrong direction for a tool that will outlive this snapshot.
- **An empty answer now throws.** A 503 saying the assistant is unavailable is
  the correct outcome for a compliance tool; a blank guidance turn stored in an
  incident record is not.

## The stub was the reason none of this was caught

The e2e stub replied with a lone text block, so the suite passed while
production read `content[0]` and stored nothing. A stub easier to parse than
the real thing tests the wrong system. It now returns the real shape — thinking
block first.

Confirmed it bites: reverting the parsing fix fails **14 tests**. Before this
change it failed none.

## Verification

`typecheck`, `lint`, `build` clean. `npm test` — 151 unit + 59 e2e passing.

Also driven through the running app against a local database: classification
correct, 10–11 obligations created per incident, coverage gaps reported without
asserting policy, no 500s and no logger crashes across three consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)