### PR TITLE
Keep an answer's provenance in the record, not just in the tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ These are asserted by the suite; move them deliberately and update the tests in
 the same commit:
 
 `data-testid="chat-input" | chat-send | chat-loading | chat-sources |
-obligation-queue | obligation-row`, `aria-label="Send message"`,
+chat-history-item | obligation-queue | obligation-row`, `aria-label="Send message"`,
 `nav[aria-label="Main"]`, the `Incidents` `<h1>`, and the button names
 `Close Incident` / `Reopen Incident` / `Generate Summary` / `Sign in` /
 `Sign out` / `Mark done`.

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -358,6 +358,54 @@ test.describe('Classification and library scope', () => {
     await expect(page.getByTestId('chat-sources')).toHaveCount(1);
     await expect(page.getByTestId('chat-sources')).toContainText('This rests on');
   });
+
+  test('reopening a past incident still shows what each answer rested on', async ({ page }) => {
+    /*
+     * Provenance used to live only in the browser tab. GET /api/chat/[id]
+     * returned id, type, content and timestamp, so reopening an incident
+     * dropped every citation the guidance rested on -- on a tool whose answers
+     * exist to be checked, and whose record is the thing an administrator goes
+     * back to weeks later.
+     *
+     * The turn kind survives the round trip too, so the distinction this
+     * feature is built on is not a live-only nicety: the reopened question
+     * turn is still bare and the reopened answer still carries its ladder.
+     */
+    await page.goto('/chat');
+
+    await page.getByTestId('chat-input').fill(
+      "A student came to me about another student, I'm not sure what happened yet."
+    );
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/chat') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: 'Send message' }).click(),
+    ]);
+
+    await page.getByTestId('chat-input').fill('It was repeated name-calling at recess.');
+    const [answered] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/chat') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: 'Send message' }).click(),
+    ]);
+    const { incidentId } = await answered.json();
+
+    // Leave the conversation entirely and come back to it the way a user does.
+    await page.reload();
+    await expect(page.getByText(STUB_REPLY)).toHaveCount(0);
+    await page
+      .locator(`[data-testid="chat-history-item"][data-incident-id="${incidentId}"]`)
+      .click();
+
+    await expect(page.getByText(STUB_QUESTION_REPLY)).toBeVisible();
+    await expect(page.getByText(STUB_REPLY)).toBeVisible();
+
+    // Exactly one block, on the answer -- not on the question above it.
+    const sources = page.getByTestId('chat-sources');
+    await expect(sources).toHaveCount(1);
+    await expect(sources).toContainText('This rests on');
+    await expect(sources).toContainText('Policy JICK: Bullying Prevention');
+    // Down to the provision, which is the half that makes a citation checkable.
+    await expect(sources).toContainText('JICK §D');
+  });
 });
 
 test.describe('A failed turn', () => {

--- a/src/app/api/chat/[incidentId]/route.ts
+++ b/src/app/api/chat/[incidentId]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import { incidentScope, requireUser } from '@/lib/session';
+import { readStoredTurn } from '@/lib/ai/conversation-metadata';
+import { ragSystem } from '@/lib/ai/rag';
 
 type Params = {
   params: Promise<{
@@ -31,13 +33,45 @@ export async function GET(request: NextRequest, { params }: Params) {
       );
     }
 
+    const stored = incident.conversations.map(conv => ({
+      conv,
+      turn: conv.sender === 'user' ? {} : readStoredTurn(conv.metadata),
+    }));
+
+    /*
+     * Coverage is a property of the incident and the library, not of a turn,
+     * so it is asked for once and only when something will render it.
+     *
+     * Recomputed rather than replayed from the record. The gap it reports is
+     * "the district has no local policy for this", and the administrator
+     * reading a month-old incident needs that answered as it stands now --
+     * loading the missing policy should clear the warning everywhere, not
+     * leave it frozen into every turn that predates the upload. It comes from
+     * `ragSystem.coverageFor`, the same call the live turn used, so the two
+     * cannot drift apart.
+     */
+    const needsCoverage = stored.some(({ turn }) => turn.citations !== undefined);
+    const coverage = needsCoverage
+      ? await ragSystem.coverageFor(incident.incidentType)
+      : undefined;
+
     // Format messages for the chat UI
-    const messages = incident.conversations.map(conv => ({
+    const messages = stored.map(({ conv, turn }) => ({
       id: conv.id,
       // Summaries render like any assistant turn; they are part of the record.
       type: conv.sender === 'user' ? 'user' : 'general',
       content: conv.message,
       timestamp: conv.timestamp,
+      /*
+       * The provenance the turn was answered with. Absent on user turns, on
+       * summaries, and on anything recorded before this was stored -- and
+       * absent is rendered as no block at all, which is honest: we do not know
+       * what that turn rested on, and an empty ladder would be a claim that it
+       * rested on nothing.
+       */
+      citations: turn.citations,
+      coverage: turn.citations === undefined ? undefined : coverage,
+      kind: turn.kind,
     }));
 
     return NextResponse.json({

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -89,6 +89,16 @@ interface Message {
   classification?: Classification | null;
 }
 
+/**
+ * One turn as GET /api/chat/[incidentId] returns it -- the stored record,
+ * whose timestamp is still a string. Typed rather than mapped through `any`,
+ * so renaming a field on either side of that boundary fails the build instead
+ * of silently dropping a turn's provenance.
+ */
+interface StoredMessage extends Omit<Message, 'timestamp'> {
+  timestamp: string;
+}
+
 interface Chat {
   id: string;
   title: string;
@@ -162,10 +172,12 @@ export default function ChatPage() {
 
       const data = await response.json();
       setIncidentId(data.incidentId);
-      setMessages(data.messages.map((m: any) => ({
-        ...m,
-        timestamp: new Date(m.timestamp)
-      })));
+      setMessages(
+        (data.messages as StoredMessage[]).map(m => ({
+          ...m,
+          timestamp: new Date(m.timestamp),
+        }))
+      );
     } catch (error) {
       console.error('Error loading conversation:', error);
       toast.error('Failed to load conversation. Please try again.');
@@ -373,10 +385,22 @@ export default function ChatPage() {
               </div>
             ) : (
               previousChats.map((chat) => (
-                <div
+                // A button, not a clickable div: this is the only way back to
+                // a past incident, and on a div it was unreachable by keyboard
+                // and announced as nothing.
+                <button
                   key={chat.id}
+                  type="button"
+                  data-testid="chat-history-item"
+                  data-incident-id={chat.id}
+                  aria-current={incidentId === chat.id ? 'true' : undefined}
                   onClick={() => loadConversation(chat.id)}
                   style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    font: 'inherit',
+                    border: 'none',
                     padding: '10px 12px',
                     marginBottom: '4px',
                     borderRadius: '8px',
@@ -401,7 +425,7 @@ export default function ChatPage() {
                   }}>
                     {chat.title}
                   </div>
-                </div>
+                </button>
               ))
             )}
           </div>

--- a/src/lib/ai/conversation-metadata.test.ts
+++ b/src/lib/ai/conversation-metadata.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { readStoredTurn } from './conversation-metadata';
+
+const CITATION = {
+  policyId: 'p1',
+  title: 'Policy JICK: Bullying Prevention',
+  jurisdiction: 'district',
+  category: 'bullying',
+  sections: ['JICK §D — Procedures for Reporting Bullying'],
+};
+
+describe('readStoredTurn', () => {
+  it('reads the citations and kind a turn recorded', () => {
+    const raw = JSON.stringify({ citations: [CITATION], kind: 'guidance' });
+    expect(readStoredTurn(raw)).toEqual({ citations: [CITATION], kind: 'guidance' });
+  });
+
+  it('ignores the fields the chat view does not need', () => {
+    const raw = JSON.stringify({
+      citations: [CITATION],
+      classification: { type: 'bullying' },
+      usage: { inputTokens: 10, outputTokens: 20 },
+      dataSensitivity: 'confidential',
+    });
+    expect(readStoredTurn(raw)).toEqual({ citations: [CITATION], kind: undefined });
+  });
+
+  /*
+   * An empty array and a missing one are different facts and both survive the
+   * round trip: retrieval ran and matched nothing, versus a turn that recorded
+   * nothing at all. The first renders the "no policy text was retrieved, at any
+   * level" caution; the second renders no block. Collapsing them would turn a
+   * stated absence into silence. (FLOW-83)
+   */
+  it('keeps an empty citations array distinct from an absent one', () => {
+    expect(readStoredTurn(JSON.stringify({ citations: [] })).citations).toEqual([]);
+    expect(readStoredTurn(JSON.stringify({ kind: 'guidance' })).citations).toBeUndefined();
+  });
+
+  it('returns nothing for a turn with no metadata', () => {
+    expect(readStoredTurn(null)).toEqual({});
+    expect(readStoredTurn(undefined)).toEqual({});
+    expect(readStoredTurn('')).toEqual({});
+  });
+
+  /*
+   * A conversation must still load when one row in the middle of it cannot be
+   * read. The alternative is an administrator locked out of an entire incident
+   * record by a truncated write.
+   */
+  it('never throws on metadata it cannot parse', () => {
+    for (const raw of ['{"citations":', 'not json at all', '[]', 'null', '"a string"', '42']) {
+      expect(() => readStoredTurn(raw), raw).not.toThrow();
+      expect(readStoredTurn(raw), raw).toEqual({});
+    }
+  });
+
+  it('reads each field independently, so one bad field does not cost the other', () => {
+    // Citations of a shape we cannot use, alongside a kind we can.
+    const badCitations = JSON.stringify({ citations: [{ title: 42 }], kind: 'question' });
+    expect(readStoredTurn(badCitations)).toEqual({ citations: undefined, kind: 'question' });
+
+    // And the reverse: a kind from some later vocabulary must not hide the
+    // citations, which are the half an administrator needs to check the answer.
+    const badKind = JSON.stringify({ citations: [CITATION], kind: 'clarifying' });
+    expect(readStoredTurn(badKind)).toEqual({ citations: [CITATION], kind: undefined });
+  });
+});

--- a/src/lib/ai/conversation-metadata.ts
+++ b/src/lib/ai/conversation-metadata.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import type { PolicyCitation } from '@/types';
+import type { TurnKind } from './turn-label';
+
+/**
+ * What a stored assistant turn can tell us about itself.
+ *
+ * `Conversation.metadata` is a JSON string written by POST /api/chat. It has
+ * accumulated fields over time and older rows predate most of them, so this
+ * reads the few the chat view needs and ignores the rest rather than
+ * describing the whole record.
+ *
+ * The reason it is read at all: the history route returned only id, type,
+ * content and timestamp, so reloading an incident dropped every citation the
+ * guidance rested on. Provenance was visible for as long as the tab stayed
+ * open and no longer -- on a tool whose answers are meant to be checked.
+ */
+const citationSchema = z.object({
+  policyId: z.string(),
+  title: z.string(),
+  jurisdiction: z.string(),
+  category: z.string(),
+  sections: z.array(z.string()).optional(),
+});
+
+// `.catch` per field, so the two are read independently: a citations array we
+// cannot make sense of must not also cost us the turn's kind, and an
+// unrecognised kind must not cost the administrator the citations.
+const storedTurnSchema = z.object({
+  citations: z.array(citationSchema).optional().catch(undefined),
+  kind: z.enum(['question', 'guidance']).optional().catch(undefined),
+});
+
+export interface StoredTurn {
+  /**
+   * The policies the turn was answered from, as recorded at the time.
+   *
+   * Undefined and empty mean different things and both are preserved: undefined
+   * is a turn that recorded nothing, which renders no provenance at all, while
+   * an empty array is a turn where retrieval ran and matched nothing, which
+   * renders the "no policy text was retrieved, at any level" caution. Collapsing
+   * them would turn a stated absence into silence. (FLOW-83)
+   */
+  citations?: PolicyCitation[];
+  kind?: TurnKind;
+}
+
+/**
+ * Read the fields the chat view needs out of a stored turn.
+ *
+ * Never throws. A row whose metadata is absent, truncated, not JSON, or JSON of
+ * some shape we no longer write yields an empty result, and the turn renders
+ * as one with nothing recorded -- which is what it is. A conversation must
+ * still load when one turn in the middle of it cannot be read; the alternative
+ * is an administrator locked out of the whole incident record by a bad row.
+ */
+export function readStoredTurn(raw: string | null | undefined): StoredTurn {
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+
+  const result = storedTurnSchema.safeParse(parsed);
+  if (!result.success) return {};
+
+  return { citations: result.data.citations, kind: result.data.kind };
+}

--- a/src/lib/ai/rag.ts
+++ b/src/lib/ai/rag.ts
@@ -345,7 +345,7 @@ export class RAGSystem {
     const references: PolicyReference[] = [];
     const policyContext = this.buildJurisdictionContext(relevantChunks, references);
     const citations = this.buildCitations(relevantChunks);
-    const coverage = await this.assessCoverage(guaranteed);
+    const coverage = await this.coverageFor(context?.incidentType);
 
     return {
       response: policyContext,
@@ -512,6 +512,23 @@ export class RAGSystem {
    * implicated category without a district or school policy is a gap, whether
    * or not federal or state authority exists above it.
    */
+  /**
+   * What the library does and does not cover for an incident of this type.
+   *
+   * Public because the chat history route needs the same answer when it
+   * rebuilds a stored conversation, and a second implementation of "which
+   * categories have no local policy" is exactly the drift policy-coverage.ts
+   * was written to avoid. Both callers reach `assessCoverage` through here, so
+   * a reloaded turn reports the gap the live turn reported.
+   *
+   * Derived from the incident type and the current library, not from what
+   * retrieval returned, so it is meaningful for a turn recorded weeks ago:
+   * what it answers is whether the district has a local policy *now*.
+   */
+  async coverageFor(incidentType?: string | null): Promise<PolicyCoverage> {
+    return this.assessCoverage(guaranteedCategoriesFor(incidentType));
+  }
+
   private async assessCoverage(categories: string[]): Promise<PolicyCoverage> {
     if (categories.length === 0) {
       return { categories, byCategory: {}, categoriesWithoutLocalPolicy: [] };


### PR DESCRIPTION
Follow-on to #31, which made the "This rests on" ladder appear only on turns that give guidance. That only ever affected live turns — reopening an incident showed no provenance on *any* turn.

## The problem

`GET /api/chat/[incidentId]` returned `id`, `type`, `content` and `timestamp`. Every citation the guidance rested on was dropped on reload, so provenance lived for exactly as long as the browser tab did — on a tool whose answers exist to be checked, and whose record is the thing an administrator goes back to weeks later.

## Citations: a projection, not a schema change

They were already stored on the conversation. `readStoredTurn` reads them back and **never throws** — metadata that is absent, truncated, not JSON, or of a shape we no longer write yields an empty result and the turn renders with no block. A conversation has to load when one row in the middle of it cannot be read; the alternative is a single bad write locking an administrator out of an entire incident record.

The two fields are parsed independently, so an unusable citations array does not also cost us the turn's kind, and an unrecognised kind does not cost the administrator the citations.

An **absent** citations array stays distinct from an **empty** one. Empty means retrieval ran and matched nothing, which renders the "no policy text was retrieved, at any level" caution (FLOW-83); absent means the turn recorded nothing, which renders no block — an empty ladder would be a claim that the turn rested on nothing.

## Coverage: recomputed, not recorded

Coverage was never stored, and I did not add it to the record. The gap it reports is *"the district has no local policy for this"*, and the reader needs that answered as it stands **now** — loading the missing policy should clear the warning everywhere, not leave it frozen into every turn that predates the upload.

`ragSystem.coverageFor` is now public and is the same call the live turn makes, so a reopened turn cannot report a different gap from the one first shown. A second implementation of "which categories have no local policy" is exactly the drift `policy-coverage.ts` was written to avoid.

## Two things fixed in passing

Both were directly in the path of the new test:

- The sidebar entry was a clickable `div` — the only way back to a past incident, unreachable by keyboard and announced as nothing. It is now a `button`, with `data-testid="chat-history-item"` recorded in `CLAUDE.md`'s test contracts.
- The loaded conversation was mapped through `any`, so renaming a field on either side of that boundary would have silently dropped provenance rather than failing the build.

## Testing

All four gates pass. 213 unit tests (up from 207), 75 e2e (up from 74).

The new e2e test sends a vague opener and a real report, reloads the page, and reopens the incident from the sidebar — asserting the question turn is still bare, the answer still carries its ladder, and the citation still names the provision (`JICK §D`) rather than just the policy.

Verified to fail: dropping the citations projection fails its "exactly one sources block" assertion with 0 received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)