### PR TITLE
Take the role from the row, not from the token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,15 @@ or query string; that was a real vulnerability. Every handler re-checks the
 session even though `middleware.ts` also gates it — a matcher mistake must not
 silently expose a route.
 
+**The session says who you are; the row says what you may do.** `requireUser()`
+re-reads the user on every guarded request, so `role` is never taken from the
+JWT: the token records the role held at sign-in, and `updateAge` rolls it
+forward on activity, so a demotion would otherwise not take effect while the
+user kept working. A deleted account is 401, not 403. `middleware.ts` still
+gates `/admin` on the token's role because Prisma cannot run on the Edge — that
+is a page shell, and every `/api/admin` handler re-checks against the row.
+(SEC-19)
+
 **Scope every by-id lookup.** `incidentScope(user)` — reporters see only what
 they filed. An out-of-scope row returns **404, not 403**, so ids are not
 confirmed to people who may not read them.

--- a/e2e/admin.smoke.spec.ts
+++ b/e2e/admin.smoke.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import { STORAGE_STATE } from '../playwright.config';
+import { TEST_USERS, deleteUserByEmail, setUserRole } from './support/seed';
 
 /**
  * Admin-only routes, which the reporter project cannot reach and therefore
@@ -29,5 +31,59 @@ test.describe('Admin routes', () => {
     await expect(
       page.locator('nav[aria-label="Main"]').locator('a[href="/admin/prompt"]').first()
     ).toBeVisible();
+  });
+});
+
+/**
+ * SEC-19. Role was read off the JWT, and the `jwt` callback only writes it at
+ * sign-in -- so a demotion took effect no sooner than the token expired, and
+ * `updateAge` rolls the token forward on activity, meaning an administrator
+ * demoted mid-shift kept administrator access for as long as they kept working.
+ * There was no mechanism to revoke anything at all.
+ *
+ * Both tests act on a session that is already signed in, because that is the
+ * only state in which the bug exists. Signing in again would mint a token
+ * carrying the new role and prove nothing.
+ */
+test.describe('Revoking access', () => {
+  test('a demoted admin loses admin access on the next request', async ({ context }) => {
+    // Prove the access exists first, or the assertion below could pass because
+    // the endpoint is broken rather than because the demotion worked.
+    expect((await context.request.get('/api/admin/policies')).status()).toBe(200);
+
+    const previous = await setUserRole(TEST_USERS.admin.email, 'reporter');
+    try {
+      const demoted = await context.request.get('/api/admin/policies');
+      expect(demoted.status()).toBe(403);
+    } finally {
+      await setUserRole(TEST_USERS.admin.email, previous);
+    }
+
+    // Restored on the same session, with no sign-in in between -- which is the
+    // other half of reading the role from the row rather than the token.
+    expect((await context.request.get('/api/admin/policies')).status()).toBe(200);
+  });
+
+  test('a deleted account is unauthenticated, not merely unauthorised', async ({ browser }) => {
+    /*
+     * The session is the one `auth.setup.ts` minted, not one signed in here.
+     * Signing in inside a test cannot work: `navigation.spec.ts` floods the
+     * credentials endpoint until the limiter refuses it, by design, and this
+     * project runs afterwards inside the same five-minute window.
+     */
+    const context = await browser.newContext({ storageState: STORAGE_STATE.revocable });
+    try {
+      expect((await context.request.get('/api/incidents')).status()).toBe(200);
+
+      // The cookie is still valid and still correctly signed. What has gone is
+      // the user it names, and that is enough: the session cannot be honoured,
+      // and it cannot be reissued either, because sign-in would fail too.
+      await deleteUserByEmail(TEST_USERS.revocable.email);
+
+      const after = await context.request.get('/api/incidents');
+      expect(after.status()).toBe(401);
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -12,6 +12,18 @@ export const TEST_PASSWORD = 'e2e-test-password-1';
 export const TEST_USERS = {
   admin: { email: 'e2e-admin@example.test', name: 'E2E Admin', role: 'admin' },
   reporter: { email: 'e2e-reporter@example.test', name: 'E2E Reporter', role: 'reporter' },
+  /**
+   * Signed in like the others and then deleted mid-test, to prove a session
+   * outlives its account by nothing. (SEC-19)
+   *
+   * It exists as a seeded user rather than one the test creates because the
+   * test must not sign in: `navigation.spec.ts` deliberately floods the
+   * credentials endpoint until the limiter refuses it, and a test signing in
+   * afterwards is refused too -- which is what happened, as a 30s wait on a
+   * "Signing in..." button. Sessions are minted in `auth.setup.ts`, which runs
+   * before any of that. It owns no incidents, so deleting it cascades nowhere.
+   */
+  revocable: { email: 'e2e-revocable@example.test', name: 'E2E Revocable', role: 'reporter' },
 } as const;
 
 /**
@@ -329,6 +341,42 @@ export async function resetDatabase(): Promise<SeededIds> {
       reporterAttachmentId: attachmentIds['e2e-reporter-statement.txt'],
       adminAttachmentId: attachmentIds['e2e-admin-statement.txt'],
     };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * Set a seeded user's role, returning the role it had.
+ *
+ * Exists so a test can revoke a privilege on a session that is already signed
+ * in, which is the only way to exercise SEC-19: role used to be read off the
+ * JWT, so a demotion did not take effect while the token lived. Nothing else
+ * in the suite can produce that state -- the storage states are minted once, in
+ * `auth.setup.ts`, and never re-signed-in.
+ *
+ * The suite runs `workers: 1, fullyParallel: false`, so a test may mutate a
+ * shared user for the length of one test. It must put the role back.
+ */
+export async function setUserRole(email: string, role: string): Promise<string> {
+  const prisma = new PrismaClient();
+  try {
+    const before = await prisma.user.findUniqueOrThrow({
+      where: { email },
+      select: { role: true },
+    });
+    await prisma.user.update({ where: { email }, data: { role } });
+    return before.role;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/** Remove a seeded account, to prove its live session dies with it. */
+export async function deleteUserByEmail(email: string): Promise<void> {
+  const prisma = new PrismaClient();
+  try {
+    await prisma.user.deleteMany({ where: { email } });
   } finally {
     await prisma.$disconnect();
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,8 @@ const BASE_URL = `http://localhost:${PORT}`;
 export const STORAGE_STATE = {
   admin: path.join(__dirname, 'e2e/.auth/admin.json'),
   reporter: path.join(__dirname, 'e2e/.auth/reporter.json'),
+  // Not a project: a session one test signs in as and then revokes.
+  revocable: path.join(__dirname, 'e2e/.auth/revocable.json'),
 };
 
 export default defineConfig({

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
 import { forbiddenError, unauthorizedError } from '@/lib/errors';
 
 export interface SessionUser {
@@ -27,17 +28,52 @@ export async function requireUser(): Promise<Guard> {
   if (!session?.user?.id) {
     return { ok: false, response: unauthorizedError() };
   }
+
+  /*
+   * The session says who you are; the database says what you may do. (SEC-19)
+   *
+   * `role` used to be read straight off the JWT, and the `jwt` callback only
+   * writes it at sign-in -- so a role change took effect no sooner than the
+   * token expired, and because `updateAge` rolls the token forward on activity,
+   * an administrator demoted mid-shift kept administrator access for as long as
+   * they kept working. Deleting the account did not end the session either.
+   * There was no mechanism to revoke anything.
+   *
+   * So the row is re-read on every guarded request. A demotion takes effect on
+   * the next request, and a deleted account is unauthenticated rather than
+   * merely unauthorised: the session names a user who no longer exists, and it
+   * cannot be reissued because sign-in would fail too. The cost is one indexed
+   * lookup per request, which is the right price for the property.
+   *
+   * The identity itself still comes from the session and never from the
+   * request -- `session.user.id` is what is looked up, and no handler may pass
+   * an id of its own.
+   */
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { id: true, email: true, name: true, role: true },
+  });
+
+  if (!user) {
+    return { ok: false, response: unauthorizedError() };
+  }
+
   return {
     ok: true,
     user: {
-      id: session.user.id,
-      email: session.user.email ?? '',
-      name: session.user.name ?? '',
-      role: session.user.role,
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
     },
   };
 }
 
+/**
+ * As `requireUser`, and additionally that the caller currently holds one of
+ * these roles -- currently, because the role comes from the row rather than
+ * from the token. See the note there.
+ */
 export async function requireRole(...roles: string[]): Promise<Guard> {
   const result = await requireUser();
   if (!result.ok) return result;


### PR DESCRIPTION
Closes SEC-19, open since the first audit and listed in the roadmap's hardening table as *"There is no mechanism at all."*

**Independent of #32 and #33** — based directly on `dev`, touching different files, so it can merge in any order.

## The hole

`role` was read straight off the JWT, and the `jwt` callback only writes it at sign-in. So a role change took effect no sooner than the token expired — and because `updateAge` rolls the token forward on activity, **an administrator demoted mid-shift kept administrator access for exactly as long as they kept working.** Deleting the account did not end the session either.

## The fix

`requireUser` re-reads the user on every guarded request. A demotion takes effect on the next one, and a deleted account is **401 rather than 403**: the session names a user who no longer exists, so it cannot be honoured — and it cannot be reissued either, because sign-in would fail too. The cost is one indexed lookup per request, which is the right price for the property.

Identity still comes from the session and never from the request. It is `session.user.id` that gets looked up; no handler may supply an id of its own.

## What this does not cover, and why that is fine

`middleware.ts` still gates `/admin` on the token's role, because Prisma cannot run on the Edge. That is a page shell — both admin pages are `'use client'` and fetch everything through `/api/admin`, which now re-checks against the row. A demoted admin who reaches the URL gets a page that can load nothing, not data they should not see.

## Testing

All four gates pass. 207 unit, 77 e2e (up from 75) on this base.

Both tests act on a session that is **already signed in**, because that is the only state in which the bug exists — signing in again would mint a token carrying the new role and prove nothing.

The revoked account is seeded, with its session minted in `auth.setup.ts`, rather than signed in from inside the test. `navigation.spec.ts` deliberately floods the credentials endpoint until the limiter refuses it, and a later sign-in in the same five-minute window is refused too. I found that the hard way — the first version of this test passed alone and then hung for 30 seconds on a disabled "Signing in…" button in the full suite.

Verified to fail: restoring the token role gives `200` where the tests expect `403` and `401`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)