### PR TITLE
Withdraw the deadline claim when the cited provision states no time

### DIFF
--- a/src/lib/ai/rag.ts
+++ b/src/lib/ai/rag.ts
@@ -448,7 +448,7 @@ export class RAGSystem {
               statute: chunk.sectionStatute ?? undefined,
             })
           : title;
-        references?.push({ n, policyId: chunk.policyId, citation: source });
+        references?.push({ n, policyId: chunk.policyId, citation: source, text: chunk.content });
         return `[${n}] ${source}\n${chunk.content}`;
       });
 

--- a/src/lib/obligation-provenance.test.ts
+++ b/src/lib/obligation-provenance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveProvenance } from './obligation-provenance';
+import { resolveProvenance, statesATimeLimit } from './obligation-provenance';
 import type { PolicyReference } from '@/types';
 
 /**
@@ -8,9 +8,27 @@ import type { PolicyReference } from '@/types';
  * a way the model can be wrong about its own reasoning.
  */
 const REFERENCES: PolicyReference[] = [
-  { n: 1, policyId: 'p-jick', citation: 'JICK §D — Procedures for Reporting (RSA 193-F:4)' },
-  { n: 2, policyId: 'p-jlf', citation: 'JLF — Reporting Child Abuse and Neglect' },
+  {
+    n: 1,
+    policyId: 'p-jick',
+    citation: 'JICK §D — Procedures for Reporting (RSA 193-F:4)',
+    text: 'The principal shall report the incident to the superintendent within 48 hours.',
+  },
+  {
+    n: 2,
+    policyId: 'p-jlf',
+    citation: 'JLF — Reporting Child Abuse and Neglect',
+    text: 'Any school employee with reason to suspect abuse shall report immediately.',
+  },
 ];
+
+/** A real provision that imposes a duty and names no clock at all. */
+const NO_CLOCK: PolicyReference = {
+  n: 3,
+  policyId: 'p-jicc',
+  citation: 'JICC §B — Conduct on School Buses',
+  text: 'Students shall obey the driver. The principal shall investigate reported misconduct and may suspend bus privileges.',
+};
 
 describe('resolveProvenance', () => {
   it('accepts an attribution that resolves to a supplied excerpt', () => {
@@ -56,6 +74,82 @@ describe('resolveProvenance', () => {
     // An empty library must not be able to produce a policy-backed deadline.
     for (const n of [1, 2, null]) {
       expect(resolveProvenance(n, []).deadlineSource).toBe('model');
+    }
+  });
+
+  /*
+   * OQ-5 named this gap and left it open: attribution "verifies that the
+   * excerpt exists and was supplied, not that the excerpt states the deadline
+   * the model attributed to it." A provision that names no time at all cannot
+   * be the source of a number of hours, and that much is decidable from the
+   * text.
+   */
+  it('withdraws the deadline claim when the cited provision states no time', () => {
+    const resolved = resolveProvenance(3, [...REFERENCES, NO_CLOCK]);
+    expect(resolved.deadlineSource).toBe('model');
+  });
+
+  it('keeps the citation on a withdrawn deadline, because it is still true', () => {
+    // The obligation does rest on this provision; only the claim about the
+    // clock is withdrawn. Dropping the citation would send an administrator
+    // checking the answer nowhere.
+    const resolved = resolveProvenance(3, [...REFERENCES, NO_CLOCK]);
+    expect(resolved.policyId).toBe('p-jicc');
+    expect(resolved.citation).toBe('JICC §B — Conduct on School Buses');
+  });
+
+  it('still accepts a provision that does state one', () => {
+    expect(resolveProvenance(1, REFERENCES).deadlineSource).toBe('policy');
+    expect(resolveProvenance(2, REFERENCES).deadlineSource).toBe('policy');
+  });
+});
+
+describe('statesATimeLimit', () => {
+  it('finds a clock written the way policy writes one', () => {
+    for (const text of [
+      'shall be reported within 24 hours',
+      'no later than 48 hours after the incident',
+      'within five (5) school days of the report',
+      'the investigation shall conclude within ten business days',
+      'the 24-hour reporting window',
+      'within 30 calendar days',
+      'within two weeks',
+      'a written report is due within 3 months',
+    ]) {
+      expect(statesATimeLimit(text), text).toBe(true);
+    }
+  });
+
+  it('counts immediacy as a clock, because the statutes are written that way', () => {
+    for (const text of [
+      'shall report immediately',
+      'shall notify the superintendent promptly',
+      'without delay',
+      'as soon as reasonably practicable',
+      'by the end of the next school day',
+      'must be filed the same day',
+    ]) {
+      expect(statesATimeLimit(text), text).toBe(true);
+    }
+  });
+
+  /*
+   * The false positives that would matter. A statute reference is full of
+   * digits and a policy is full of section numbers, and neither states when
+   * anything is due -- if these qualified, the check would confirm every
+   * deadline it was asked about and be worth nothing.
+   */
+  it('is not fooled by the numbers policy text is full of', () => {
+    for (const text of [
+      'RSA 193-F:4, II(f) - (h)',
+      'Policy JICK, adopted October 3, 2024; revised July 2026',
+      'See Section 5 and Section 12 of this policy',
+      'Ed 306.04(a)(8)',
+      'The principal shall investigate and document the findings.',
+      'Students shall obey the driver at all times.',
+      'reported on school days to the building principal',
+    ]) {
+      expect(statesATimeLimit(text), text).toBe(false);
     }
   });
 });

--- a/src/lib/obligation-provenance.ts
+++ b/src/lib/obligation-provenance.ts
@@ -11,6 +11,62 @@ export interface Provenance {
 
 const UNVERIFIED: Provenance = { deadlineSource: 'model', policyId: null, citation: null };
 
+/*
+ * A quantity followed by a unit of time: "24 hours", "within 5 school days",
+ * "ten (10) business days", "48-hour". The optional parenthetical is how
+ * policy text usually writes a number twice -- "five (5) school days" -- and
+ * the hyphen is how it writes an adjective, "the 24-hour reporting window".
+ *
+ * Spelled-out numbers are listed rather than matched generically because the
+ * bare word "days" must not qualify on its own: "school days" appears in
+ * plenty of provisions that set no clock at all.
+ */
+const QUANTITY = String.raw`\d+|one|two|three|four|five|six|seven|eight|nine|ten|` +
+  String.raw`eleven|twelve|fifteen|twenty|thirty|forty[- ]?five|sixty|ninety`;
+const TIME_UNIT = String.raw`hours?|days?|weeks?|months?`;
+const QUANTIFIED_TIME = new RegExp(
+  String.raw`\b(?:${QUANTITY})\b[\s\-\u2013\u2014]*(?:\([^)]*\)[\s\-]*)?` +
+    String.raw`(?:business|school|calendar|working)?[\s\-]*(?:${TIME_UNIT})\b`,
+  'i'
+);
+
+/*
+ * Deadlines that name no number. "Immediately" is as much a clock as "within
+ * 24 hours", and mandatory-reporting statutes are written in exactly these
+ * words, so a provision using them has stated a time limit.
+ */
+const IMMEDIACY =
+  /\b(?:immediately|promptly|forthwith|without delay|as soon as (?:possible|practicable|reasonably)|same[- ](?:school[- ])?day|end of the (?:next[- ])?(?:school[- ])?day|no later than)\b/i;
+
+/**
+ * Does this provision state a time limit at all?
+ *
+ * The question a deadline's provenance turns on. `resolveProvenance` could
+ * previously confirm only that the excerpt the model named was one it had been
+ * given -- not that the excerpt says anything about when. A model citing a real
+ * provision for a number that provision does not contain produced a
+ * policy-backed row, with the red countdown that goes with it, and OQ-5 said so
+ * in as many words: attribution "verifies that the excerpt exists and was
+ * supplied, **not** that the excerpt states the deadline the model attributed
+ * to it."
+ *
+ * This closes the half of that gap that needs no calibration. A provision
+ * containing no time expression whatsoever cannot be the source of a number of
+ * hours, whatever the model claims -- that is decidable from the text alone.
+ *
+ * **What it deliberately does not do** is check that the time it found is the
+ * time the model derived. An excerpt is up to a thousand characters and may
+ * carry several provisions, so a clock found anywhere in it satisfies this. The
+ * result is a check that only ever *downgrades*: a false positive here leaves
+ * today's behaviour untouched, and there is no input on which it can promote a
+ * model's guess to policy-backed. Matching the specific number to the specific
+ * obligation is the remaining half, and it still wants real incidents to
+ * calibrate against.
+ */
+export function statesATimeLimit(text: string): boolean {
+  return QUANTIFIED_TIME.test(text) || IMMEDIACY.test(text);
+}
+
 /**
  * Resolve the model's claim about where a deadline came from.
  *
@@ -38,7 +94,18 @@ export function resolveProvenance(
   if (!reference) return UNVERIFIED;
 
   return {
-    deadlineSource: 'policy',
+    /*
+     * The excerpt was supplied and the model named it. Whether it can support a
+     * *deadline* is a further question, and one the text answers: a provision
+     * stating no time limit at all did not produce a number of hours.
+     *
+     * The citation and policy id survive that demotion, because they are still
+     * true -- the obligation does rest on this provision, and an administrator
+     * checking the answer needs to be sent to it. Only the claim about the
+     * clock is withdrawn, which is exactly what `deadlineSource` governs: the
+     * countdown loses its red and reads as unverified. (OQ-5)
+     */
+    deadlineSource: statesATimeLimit(reference.text) ? 'policy' : 'model',
     policyId: reference.policyId,
     citation: reference.citation,
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -362,6 +362,14 @@ export interface PolicyReference {
   policyId: string;
   /** Formatted reference, e.g. "JICK §F — Investigative Procedures (RSA ...)". */
   citation: string;
+  /**
+   * The excerpt text the model was shown under this number.
+   *
+   * Required, not optional: it is what lets an attribution be checked against
+   * the provision rather than only against the numbering. A producer that has
+   * no text has nothing to check, and should say so by failing to compile.
+   */
+  text: string;
 }
 
 /** One policy cited in a response, with enough detail for the UI to show it. */


### PR DESCRIPTION
**Re-opening #33 against `dev`.** It was merged, but into the wrong branch.

#33's base was `chat/history-provenance` (it was stacked on #32). GitHub retargets a stacked PR only when its base branch is *deleted*, and that branch still exists — so no retarget happened. Then the ordering finished the job: #32 merged `chat/history-provenance` into `dev` **before** #33 merged into it, so this work landed on a branch that had already been absorbed. `dev` has no `statesATimeLimit`.

No content change from #33 — the same single commit, now based directly on `dev` (its parent `164fb90` is already there, so this diff is exactly the missing work).

---

## The gap

OQ-5 named this and left it open, in as many words: attribution *"verifies that the excerpt exists and was supplied, **not** that the excerpt states the deadline the model attributed to it."*

So a model citing a real provision for a number that provision does not contain produced a `policy`-sourced obligation — and with it the red countdown, which is the strongest claim to fact this product makes. On a tool where "a confidently wrong statutory deadline is worse than no answer", that is the wrong direction to be wrong in.

## What this closes

The half that needs no calibration, because it is decidable from the text alone: **a provision containing no time expression at all cannot be the source of a number of hours.** `statesATimeLimit` asks that question and `resolveProvenance` demotes an attribution that fails it.

Immediacy counts as a clock — "report immediately" is as much a deadline as "within 24 hours", and the mandatory-reporting statutes are written in those words.

## What survives the demotion

The **citation and policy id are kept**. The obligation does rest on the provision named; it is only the claim about the *clock* that is withdrawn, which is exactly what `deadlineSource` governs. Dropping them would send an administrator checking the answer nowhere, and the countdown already reads as unverified without them.

This is a deliberate change to what `deadlineSource: 'model'` implies. It previously meant "no excerpt resolved, so no citation either"; it now also covers "the excerpt resolved but sets no clock", which carries one.

## What it deliberately does not do

It does not check that the time it found is the time the model derived. An excerpt runs to a thousand characters and may carry several provisions, so a clock found anywhere in it satisfies the check.

That makes it **one-directional**: it can only ever downgrade, there is no input on which it promotes a guess to policy-backed, and a miss leaves today's behaviour exactly as it was. Matching a specific number to a specific obligation is the remaining half, and it still wants real incidents to calibrate against — step 6 on the roadmap.

## Testing

All four gates passed on #33 before it merged, and CI will re-run here on the `dev` base.

Nine of the twelve new assertions are the false positives that would matter. A statute reference (`RSA 193-F:4, II(f) - (h)`), a section number, an adoption date, an `Ed 306.04(a)(8)` cite and a bare "reported on school days" are what policy text is full of — a check that read any of them as a deadline would confirm every attribution it was asked about and be worth nothing.

`PolicyReference.text` is required rather than optional: a producer with no excerpt text has nothing to check, and should say so by failing to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)