### PR TITLE
Navigation into incidents and conversations, and one advisor profile

### DIFF
--- a/e2e/admin.smoke.spec.ts
+++ b/e2e/admin.smoke.spec.ts
@@ -214,6 +214,29 @@ test.describe('Advisor profile', () => {
     await expect(editor(page)).toHaveValue(first);
   });
 
+  test('reuses the one row instead of minting another on every save', async ({ page }) => {
+    /*
+     * The editor used to POST whenever it held no *active* profile, which is
+     * not the same condition as none existing. A deactivated row plus a
+     * listless UI meant every save created another row nobody could reach,
+     * and any of them could later be picked up as "the active profile".
+     */
+    await page.goto('/admin/prompt');
+    await editor(page).fill('First wording for the district.');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
+
+    await editor(page).fill('Second wording for the district.');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
+
+    // Two saves, one row. Counted through the API rather than the UI, which
+    // no longer shows a list and so could not reveal the extras.
+    const { prompts } = await (await page.request.get('/api/admin/prompts')).json();
+    expect(prompts).toHaveLength(1);
+    expect(prompts.filter((p: { isActive: boolean }) => p.isActive)).toHaveLength(1);
+  });
+
   test('restores the shipped default over an edit', async ({ page }) => {
     await page.goto('/admin/prompt');
     await editor(page).fill('Something else entirely.');

--- a/e2e/admin.smoke.spec.ts
+++ b/e2e/admin.smoke.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { STORAGE_STATE } from '../playwright.config';
-import { TEST_USERS, deleteUserByEmail, setUserRole } from './support/seed';
+import {
+  TEST_USERS,
+  clearAdvisorProfiles,
+  deleteUserByEmail,
+  setUserRole,
+} from './support/seed';
 
 /** Admin-only routes, which the reporter project cannot reach. */
 test.describe('Admin routes', () => {
@@ -137,5 +142,82 @@ test.describe('Policy update validation', () => {
       data: { title: policy.title },
     });
     expect(response.status()).toBe(200);
+  });
+});
+
+/**
+ * One advisor profile, and both ways back to a known text.
+ *
+ * The fixture seeds no `SystemPrompt`, which is the state a district starts
+ * in: the model is being sent the in-code default, so that is what the editor
+ * must show rather than an empty box.
+ */
+test.describe('Advisor profile', () => {
+  const editor = (page: import('@playwright/test').Page) =>
+    page.getByLabel('Profile content');
+
+  // These write real rows, and one asserts that no undo exists before the
+  // first save. Both need the seeded state, including on a retry.
+  test.beforeEach(async () => { await clearAdvisorProfiles(); });
+  test.afterAll(async () => { await clearAdvisorProfiles(); });
+
+  test('shows the shipped default when nothing is configured', async ({ page }) => {
+    await page.goto('/admin/prompt');
+    await expect(editor(page)).toContainText('trusted compliance advisor');
+    await expect(page.getByTestId('profile-status')).toHaveText('Using the shipped default');
+    // Already the original, so there is nothing to restore to.
+    await expect(page.getByRole('button', { name: 'Restore original' })).toBeDisabled();
+    // Nothing has been saved, so there is no save to undo.
+    await expect(page.getByRole('button', { name: 'Undo last save' })).toHaveCount(0);
+  });
+
+  test('saves an edit, then undoes the one after it', async ({ page }) => {
+    const first = 'Keep answers to three sentences and name the form section.';
+    const second = 'Ask about the bus route before anything else.';
+
+    /*
+     * Save, then wait for the write to land before navigating. Reloading on
+     * the click aborts the request in flight -- the server logs an ECONNRESET
+     * and the row keeps its old text -- so the wait is what makes each step
+     * mean what it says. Save going disabled is the app's own report that
+     * there is nothing unsaved left.
+     */
+    const save = async () => {
+      const button = page.getByRole('button', { name: 'Save', exact: true });
+      await button.click();
+      await expect(button).toBeDisabled();
+    };
+
+    await page.goto('/admin/prompt');
+    await editor(page).fill(first);
+    await save();
+    await expect(page.getByTestId('profile-status')).toHaveText('Active');
+
+    // The edit survives a reload, so it is the row the model will be sent.
+    await page.reload();
+    await expect(editor(page)).toHaveValue(first);
+
+    // Nothing to undo yet: this row had no earlier saved text, and the way
+    // back to the shipped wording is "Restore original".
+    await expect(page.getByRole('button', { name: 'Undo last save' })).toHaveCount(0);
+
+    await editor(page).fill(second);
+    await save();
+    await page.reload();
+    await expect(editor(page)).toHaveValue(second);
+
+    // One level, and it is the previous saved text rather than the default.
+    await page.getByRole('button', { name: 'Undo last save' }).click();
+    await expect(editor(page)).toHaveValue(first);
+    await save();
+    await page.reload();
+    await expect(editor(page)).toHaveValue(first);
+  });
+
+  test('restores the shipped default over an edit', async ({ page }) => {
+    await page.goto('/admin/prompt');
+    await editor(page).fill('Something else entirely.');
+    await page.getByRole('button', { name: 'Restore original' }).click();
+    await expect(editor(page)).toHaveValue(/trusted compliance advisor/);
   });
 });

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { test, expect } from '@playwright/test';
 import { STUB_REPLY, STUB_QUESTION_REPLY } from './support/claude-stub';
 
@@ -404,6 +405,39 @@ test.describe('Classification and library scope', () => {
     await expect(sources).toContainText('Policy JICK: Bullying Prevention');
     // Down to the provision, which is the half that makes a citation checkable.
     await expect(sources).toContainText('JICK §D');
+  });
+
+  test('opens the incident named in the URL, so an obligation can link here', async ({ page }) => {
+    /*
+     * The obligation queue and the incident page both send an administrator
+     * back to the conversation. Reopening was previously reachable only by
+     * clicking the sidebar, which is internal state and cannot be linked to.
+     */
+    await page.goto('/chat');
+    await page.getByTestId('chat-input').fill('Two students were fighting on the bus this morning.');
+    const [answered] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/chat') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: 'Send message' }).click(),
+    ]);
+    const { incidentId } = await answered.json();
+
+    await page.goto(`/chat?incident=${incidentId}`);
+    await expect(page.getByText(STUB_REPLY)).toBeVisible();
+    await expect(
+      page.locator(`[data-testid="chat-history-item"][data-incident-id="${incidentId}"]`)
+    ).toHaveAttribute('aria-current', 'true');
+  });
+
+  test('does not confirm an incident the reporter may not read', async ({ page }) => {
+    // 404, not 403, all the way to the UI: a foreign id must not be revealed
+    // as existing. The thread stays empty and nothing is marked current.
+    const { adminIncidentId } = JSON.parse(readFileSync('e2e/.auth/seed.json', 'utf8'));
+    await page.goto(`/chat?incident=${adminIncidentId}`);
+    await expect(page.getByTestId('chat-input')).toBeVisible();
+    await expect(page.getByTestId('chat-sources')).toHaveCount(0);
+    await expect(
+      page.locator(`[data-testid="chat-history-item"][data-incident-id="${adminIncidentId}"]`)
+    ).toHaveCount(0);
   });
 });
 

--- a/e2e/chat-flow.spec.ts
+++ b/e2e/chat-flow.spec.ts
@@ -428,6 +428,29 @@ test.describe('Classification and library scope', () => {
     ).toHaveAttribute('aria-current', 'true');
   });
 
+  test('keeps the address on the thread that is open', async ({ page }) => {
+    // `?incident=` is read on mount, so an address left naming the previous
+    // thread sends a reload somewhere the user has already navigated away
+    // from.
+    await page.goto('/chat');
+    await page.getByTestId('chat-input').fill('A student reported name-calling in the corridor.');
+    const [answered] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/chat') && r.request().method() === 'POST'),
+      page.getByRole('button', { name: 'Send message' }).click(),
+    ]);
+    const { incidentId } = await answered.json();
+
+    await expect(page).toHaveURL(new RegExp(`incident=${incidentId}`));
+
+    // And the address survives the round trip it now promises.
+    await page.reload();
+    await expect(page.getByText(STUB_REPLY)).toBeVisible();
+
+    // Starting a new chat drops it, or the next reload reopens the old one.
+    await page.getByRole('button', { name: /New chat/i }).click();
+    await expect(page).toHaveURL(/\/chat$/);
+  });
+
   test('does not confirm an incident the reporter may not read', async ({ page }) => {
     // 404, not 403, all the way to the UI: a foreign id must not be revealed
     // as existing. The thread stays empty and nothing is marked current.

--- a/e2e/incident-management.spec.ts
+++ b/e2e/incident-management.spec.ts
@@ -336,6 +336,16 @@ test.describe('Obligation queue', () => {
     // before midnight.
     await expect(queue.getByTestId('obligation-row')).toHaveCount(open.length);
 
+    // Every row names its incident and that name is the way into it: the queue
+    // is cross-incident, so a row with no route to its record is a dead end.
+    // Asserted as a set, because the rows are grouped by deadline state and do
+    // not come back in the API's order.
+    const rowLinks = await queue.getByTestId('obligation-row').getByRole('link').all();
+    expect(rowLinks).toHaveLength(open.length);
+    const hrefs = await Promise.all(rowLinks.map(l => l.getAttribute('href')));
+    const expected = new Set(open.map((o: { incidentId: string }) => `/incidents/${o.incidentId}`));
+    for (const href of hrefs) expect(expected).toContain(href);
+
     // And specifically that an unverified, already-late row is among them,
     // under a heading that does not claim a statutory clock.
     const unverifiedLate = open.filter(

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -66,6 +66,7 @@ test.describe('Navigation', () => {
       ['post', '/api/admin/policies/upload'],
       ['post', '/api/admin/prompts'],
       ['put', '/api/admin/prompts/any-id'],
+      ['put', '/api/admin/prompts/active'],
       ['delete', '/api/admin/prompts/any-id'],
     ];
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -87,6 +87,21 @@ test.describe('Navigation', () => {
     expect((await page.request.get('/api/policies?active=true')).status()).toBe(200);
   });
 
+  test('a reporter cannot read the admin-only configuration either', async ({ page }) => {
+    // Roles refuse verbs, and reading is a verb. The advisor profile is what
+    // the district tells the model to be; it is not a reporter's to read, and
+    // `/active` is a static segment beside `[id]` so it needs its own proof
+    // that the guard is on it rather than only on its neighbours.
+    for (const url of [
+      '/api/admin/prompts',
+      '/api/admin/prompts/active',
+      '/api/admin/prompts/any-id',
+    ]) {
+      const response = await page.request.get(url);
+      expect(response.status(), `GET ${url} should be refused for a reporter`).toBe(403);
+    }
+  });
+
   test('the health probe is reachable without a session and says nothing else', async ({
     browser,
   }) => {

--- a/e2e/support/seed.ts
+++ b/e2e/support/seed.ts
@@ -351,6 +351,24 @@ export async function resetDatabase(): Promise<SeededIds> {
  * The suite runs `workers: 1, fullyParallel: false`, so a test may mutate a
  * shared user for the length of one test. It must put the role back.
  */
+/**
+ * Put the advisor profile back to the state `resetDatabase` leaves: none
+ * configured, so the app is running on the in-code default.
+ *
+ * The profile tests write real rows, and one of them asserts that no undo is
+ * offered before anything has been saved. That is only true from a clean
+ * start, so they cannot inherit a row from an earlier attempt -- a retry would
+ * otherwise begin one save further along and pass or fail on leftovers.
+ */
+export async function clearAdvisorProfiles(): Promise<void> {
+  const prisma = new PrismaClient();
+  try {
+    await prisma.systemPrompt.deleteMany();
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
 export async function setUserRole(email: string, role: string): Promise<string> {
   const prisma = new PrismaClient();
   try {

--- a/prisma/migrations/20260910024025_add_system_prompt_previous_content/migration.sql
+++ b/prisma/migrations/20260910024025_add_system_prompt_previous_content/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."SystemPrompt" ADD COLUMN     "previousContent" TEXT;

--- a/prisma/migrations/20260910030000_one_active_system_prompt/migration.sql
+++ b/prisma/migrations/20260910030000_one_active_system_prompt/migration.sql
@@ -1,0 +1,23 @@
+-- Exactly one advisor profile may be active.
+--
+-- The chat path and the admin editor each resolved "the active profile" with
+-- their own query, so with two active rows an admin could edit one while the
+-- model was sent the other. They share one resolver now, but agreement by
+-- convention is not the same as agreement by construction: this is what makes
+-- the second row impossible rather than merely unlikely.
+--
+-- Prisma cannot express a partial unique index, so it is raw SQL. Any extra
+-- active rows are stood down first, newest kept, or the index cannot be built.
+UPDATE "SystemPrompt"
+SET "isActive" = false
+WHERE "isActive" = true
+  AND id <> (
+    SELECT id FROM "SystemPrompt"
+    WHERE "isActive" = true
+    ORDER BY "updatedAt" DESC, id ASC
+    LIMIT 1
+  );
+
+CREATE UNIQUE INDEX "SystemPrompt_one_active"
+  ON "SystemPrompt" ("isActive")
+  WHERE "isActive";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -159,6 +159,7 @@ model ComplianceAction {
   @@index([status])
   @@index([assignedTo])
   @@index([dueDate])
+  @@index([policyId])
 }
 
 // ============================================
@@ -305,6 +306,13 @@ model SystemPrompt {
   name     String // Friendly name like "Friendly Advisor", "Strict Legal", etc.
   content  String // The full system prompt text
   isActive Boolean @default(false)
+
+  /// The content this row held before the most recent save, so an admin can
+  /// undo one. Null until the first edit. One level only: `AuditLog` records
+  /// that a prompt changed and who changed it, which is what a review needs;
+  /// this exists so a bad edit to the text the model is given is recoverable
+  /// without one.
+  previousContent String?
 
   // Metadata
   description String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,6 +301,14 @@ model AuditLog {
 // SYSTEM PROMPTS
 // ============================================
 
+/// The advisor profile. Exactly one row may be active -- enforced by a partial
+/// unique index, not by convention, because the chat path and the admin editor
+/// both resolve "the active profile" and must never disagree about which it is.
+///
+/// Rows left inactive by the profile list this UI used to offer are kept
+/// rather than deleted: they are text a district wrote, and the editor no
+/// longer creates them, so the table cannot grow new ones. `saveActiveProfile`
+/// reuses the most recently updated row instead of inserting.
 model SystemPrompt {
   id       String  @id @default(cuid())
   name     String // Friendly name like "Friendly Advisor", "Strict Legal", etc.

--- a/src/app/admin/prompt/page.tsx
+++ b/src/app/admin/prompt/page.tsx
@@ -1,183 +1,119 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Navbar from '@/components/Navbar';
 import { Button } from '@/components/ui/button';
-import { Save, Plus, Trash2, Check, X } from 'lucide-react';
+import { Save } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { DEFAULT_ADVISOR_PROFILE } from '@/lib/ai/advisor-profile';
 
-interface SystemPrompt {
+/**
+ * One advisor profile, editable in place.
+ *
+ * There is deliberately no list. Only one profile can ever be active, so a
+ * gallery of alternatives offered a choice the product does not have -- and it
+ * hid the thing it was replacing: creating a second profile silently displaced
+ * the in-code default, which appeared nowhere in this UI, so an admin could
+ * not see what they had just stopped using.
+ *
+ * Both ways back are here instead. "Restore original" is the shipped default,
+ * read from the same constant the server sends to the model. "Undo last save"
+ * is the text this row held before the most recent edit. Neither writes on its
+ * own: they load the text into the editor, so the admin sees it before Save.
+ */
+interface Profile {
   id: string;
   name: string;
   content: string;
-  description?: string;
+  previousContent: string | null;
   isActive: boolean;
-  createdAt: string;
   updatedAt: string;
 }
 
+const PROFILE_NAME = 'Advisor profile';
+
 export default function PromptEditorPage() {
-  const [prompts, setPrompts] = useState<SystemPrompt[]>([]);
-  const [selectedPrompt, setSelectedPrompt] = useState<SystemPrompt | null>(null);
-  const [isEditing, setIsEditing] = useState(false);
-  const [isCreating, setIsCreating] = useState(false);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
-  const [name, setName] = useState('');
-  const [content, setContent] = useState('');
-  const [description, setDescription] = useState('');
-
-  useEffect(() => {
-    fetchPrompts();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const fetchPrompts = async () => {
+  const load = useCallback(async () => {
     try {
-      const response = await fetch('/api/admin/prompts');
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      const data = await response.json();
+      const response = await fetch('/api/admin/prompts/active');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const { prompt } = await response.json();
 
-      const promptsArray = data.prompts || [];
-      setPrompts(promptsArray);
-
-      const activePrompt = promptsArray.find((p: SystemPrompt) => p.isActive);
-      if (activePrompt) {
-        loadPrompt(activePrompt.id);
-      } else if (promptsArray.length > 0) {
-        loadPrompt(promptsArray[0].id);
+      if (!prompt) {
+        // Nothing configured: the model is being sent the in-code default, so
+        // that is what the editor should show rather than an empty box.
+        setProfile(null);
+        setContent(DEFAULT_ADVISOR_PROFILE);
+        return;
       }
+
+      setProfile(prompt);
+      setContent(prompt.content);
     } catch (error) {
-      console.error('Error fetching prompts:', error);
-      // Don't show alert, just silently fail and show empty state
-      setPrompts([]); // Set to empty array on error
+      console.error('Error loading advisor profile:', error);
+      toast.error('Could not load the advisor profile.');
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const loadPrompt = async (id: string) => {
-    try {
-      const response = await fetch(`/api/admin/prompts/${id}`);
-      const data = await response.json();
-      setSelectedPrompt(data.prompt);
-      setName(data.prompt.name);
-      setContent(data.prompt.content);
-      setDescription(data.prompt.description || '');
-      setIsEditing(false);
-      setIsCreating(false);
-    } catch (error) {
-      console.error('Error loading prompt:', error);
-      alert('Failed to load prompt');
-    }
-  };
-
-  const handleCreateNew = () => {
-    setSelectedPrompt(null);
-    setName('');
-    setContent('');
-    setDescription('');
-    setIsCreating(true);
-    setIsEditing(true);
-  };
+  useEffect(() => {
+    load();
+  }, [load]);
 
   const handleSave = async () => {
-    if (!name.trim() || !content.trim()) {
-      alert('Name and content are required');
+    if (content.trim().length < 10) {
+      toast.error('The profile needs at least 10 characters.');
       return;
     }
-
     setSaving(true);
     try {
-      if (isCreating) {
-        const response = await fetch('/api/admin/prompts', {
+      let id = profile?.id;
+
+      // No row yet: the district has been running on the in-code default.
+      if (!id) {
+        const created = await fetch('/api/admin/prompts', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, content, description, createdBy: 'admin' })
+          body: JSON.stringify({ name: PROFILE_NAME, content }),
         });
-
-        if (!response.ok) throw new Error('Failed to create prompt');
-
-        const data = await response.json();
-        await fetchPrompts();
-        await loadPrompt(data.prompt.id);
-        alert('Prompt created successfully');
-      } else if (selectedPrompt) {
-        const response = await fetch(`/api/admin/prompts/${selectedPrompt.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name, content, description })
-        });
-
-        if (!response.ok) throw new Error('Failed to update prompt');
-
-        await fetchPrompts();
-        await loadPrompt(selectedPrompt.id);
-        alert('Prompt updated successfully');
+        if (!created.ok) throw new Error('create failed');
+        id = (await created.json()).prompt.id as string;
       }
-    } catch (error) {
-      console.error('Error saving prompt:', error);
-      alert('Failed to save prompt');
-    } finally {
-      setSaving(false);
-    }
-  };
 
-  const handleActivate = async () => {
-    if (!selectedPrompt) return;
-
-    setSaving(true);
-    try {
-      const response = await fetch(`/api/admin/prompts/${selectedPrompt.id}`, {
+      // Always through PUT, including straight after a create: POST leaves a
+      // prompt inactive by design, and activation is what this write is for.
+      const response = await fetch(`/api/admin/prompts/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isActive: true })
+        body: JSON.stringify({ content, isActive: true }),
       });
+      if (!response.ok) throw new Error('save failed');
 
-      if (!response.ok) throw new Error('Failed to activate prompt');
-
-      await fetchPrompts();
-      await loadPrompt(selectedPrompt.id);
-      alert('Prompt activated successfully');
+      await load();
+      toast.success('Advisor profile saved.');
     } catch (error) {
-      console.error('Error activating prompt:', error);
-      alert('Failed to activate prompt');
+      console.error('Error saving advisor profile:', error);
+      toast.error('Could not save the advisor profile.');
     } finally {
       setSaving(false);
     }
   };
 
-  const handleDelete = async () => {
-    if (!selectedPrompt) return;
-
-    if (!confirm('Are you sure you want to delete this prompt?')) return;
-
-    try {
-      const response = await fetch(`/api/admin/prompts/${selectedPrompt.id}`, {
-        method: 'DELETE'
-      });
-
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Failed to delete prompt');
-      }
-
-      await fetchPrompts();
-      setSelectedPrompt(null);
-      alert('Prompt deleted successfully');
-    } catch (error: any) {
-      console.error('Error deleting prompt:', error);
-      alert(error.message || 'Failed to delete prompt');
-    }
-  };
+  const dirty = profile ? content !== profile.content : content !== DEFAULT_ADVISOR_PROFILE;
+  const isOriginal = content === DEFAULT_ADVISOR_PROFILE;
+  const previous = profile?.previousContent ?? null;
 
   if (loading) {
     return (
       <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
         <Navbar />
-        <div className="flex items-center justify-center h-screen">
+        <div className="flex h-screen items-center justify-center">
           <p className="body-text" style={{ color: 'var(--color-text-muted)' }}>Loading...</p>
         </div>
       </div>
@@ -187,20 +123,14 @@ export default function PromptEditorPage() {
   return (
     <div className="min-h-screen" style={{ background: 'var(--color-bg)' }}>
       <Navbar />
-      <div className="container mx-auto px-4 py-8 max-w-7xl">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="heading-xl" style={{ color: 'var(--color-text)' }}>Advisor Profile</h1>
-          <Button onClick={handleCreateNew}>
-            <Plus size={20} style={{ marginRight: '8px' }} />
-            New Profile
-          </Button>
-        </div>
+      <div className="container mx-auto max-w-4xl px-4 py-8">
+        <h1 className="heading-xl mb-6" style={{ color: 'var(--color-text)' }}>Advisor Profile</h1>
 
         {/*
           Says what this actually controls, which is the chat guidance only:
           classification and summaries use fixed prompts, and the compliance
           rules live in code and are prepended to every call, so nothing edited
-          here can remove them. "System Prompt Editor" would imply otherwise.
+          here can remove them.
         */}
         <div className="mb-6 rounded-[16px] border border-line bg-surface px-5 py-4 text-[14px] leading-[1.6] text-text-secondary">
           <span className="font-medium text-text">
@@ -213,210 +143,78 @@ export default function PromptEditorPage() {
           use their own fixed prompts and are not affected by this profile.
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Sidebar - Prompt List */}
-          <div className="lg:col-span-1">
-            <div className="card">
-              <h2 className="heading-md mb-4" style={{ color: 'var(--color-text)' }}>Saved Prompts</h2>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-2)' }}>
-                {(prompts || []).map((prompt) => (
-                  <button
-                    key={prompt.id}
-                    onClick={() => loadPrompt(prompt.id)}
-                    className={`list-row text-left ${
-                      selectedPrompt?.id === prompt.id ? 'bg-[var(--color-text)] text-[var(--color-bg)]' : ''
-                    }`}
-                    style={{
-                      width: '100%',
-                      justifyContent: 'flex-start'
-                    }}
-                  >
-                    {/* min-w-0 at both levels: `.list-row` is a flex container, so
-                        without it these items keep their content width and `truncate`
-                        never gets a bound to ellipsise against. */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="label-sm font-medium truncate min-w-0">{prompt.name}</span>
-                        {/* Neutral: an isActive flag is not a deadline state. */}
-                        {prompt.isActive && (
-                          <span
-                            className="badge flex-shrink-0 ml-2"
-                            style={{ fontSize: '12px' }}
-                          >
-                            Active
-                          </span>
-                        )}
-                      </div>
-                      {prompt.description && (
-                        <p className="caption mt-1 truncate" style={{ opacity: 0.7 }}>
-                          {prompt.description}
-                        </p>
-                      )}
-                    </div>
-                  </button>
-                ))}
-              </div>
-            </div>
+        <div className="card">
+          <label htmlFor="profile-content" className="eyebrow mb-2 block">
+            Profile content
+          </label>
+          <textarea
+            id="profile-content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            spellCheck={false}
+            className="w-full rounded-[12px] border border-input bg-bg p-4 font-mono text-[13px] leading-[1.6] text-text"
+            style={{ minHeight: '420px', resize: 'vertical' }}
+          />
+
+          <p className="mt-2 text-[12px] text-text-muted">
+            <span className="font-mono tabular-nums">{content.length}</span> characters
+            {profile && !dirty && ' · saved'}
+            {dirty && ' · unsaved changes'}
+          </p>
+
+          <div className="mt-5 flex flex-wrap items-center gap-2">
+            <Button onClick={handleSave} disabled={saving || !dirty}>
+              <Save size={18} style={{ marginRight: '8px' }} />
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+
+            <button
+              type="button"
+              onClick={() => setContent(DEFAULT_ADVISOR_PROFILE)}
+              disabled={isOriginal}
+              className="min-h-[44px] rounded-[12px] border border-line px-4 text-[14px] text-text-secondary transition-colors hover:border-line-strong hover:text-text disabled:opacity-40"
+            >
+              Restore original
+            </button>
+
+            {/* Absent, not merely disabled, until an edit has been saved -- an
+                undo that has never had anything to undo is noise. */}
+            {previous !== null && (
+              <button
+                type="button"
+                onClick={() => setContent(previous)}
+                disabled={content === previous}
+                className="min-h-[44px] rounded-[12px] border border-line px-4 text-[14px] text-text-secondary transition-colors hover:border-line-strong hover:text-text disabled:opacity-40"
+              >
+                Undo last save
+              </button>
+            )}
+
+            {dirty && (
+              <button
+                type="button"
+                onClick={() => setContent(profile ? profile.content : DEFAULT_ADVISOR_PROFILE)}
+                className="min-h-[44px] px-2 text-[14px] text-text-muted underline underline-offset-2 hover:text-text"
+              >
+                Discard changes
+              </button>
+            )}
           </div>
+        </div>
 
-          {/* Main Editor */}
-          <div className="lg:col-span-3">
-            <div className="card">
-              {selectedPrompt || isCreating ? (
-                <>
-                  {/* Header */}
-                  <div className="flex items-center justify-between mb-6">
-                    <div className="flex-1">
-                      {isEditing ? (
-                        <input
-                          type="text"
-                          value={name}
-                          onChange={(e) => setName(e.target.value)}
-                          placeholder="Prompt name..."
-                          className="field heading-lg"
-                          style={{ fontWeight: 600 }}
-                        />
-                      ) : (
-                        <h2 className="heading-lg" style={{ color: 'var(--color-text)' }}>{selectedPrompt?.name}</h2>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 ml-4">
-                      {!isEditing ? (
-                        <>
-                          <Button
-                            onClick={() => setIsEditing(true)}
-                            variant="secondary"
-                            size="sm"
-                          >
-                            Edit
-                          </Button>
-                          {!selectedPrompt?.isActive && (
-                            <Button
-                              onClick={handleActivate}
-                              disabled={saving}
-                              size="sm"
-                            >
-                              <Check size={20} style={{ marginRight: 'var(--spacing-2)' }} />
-                              Activate
-                            </Button>
-                          )}
-                          <Button
-                            onClick={handleDelete}
-                            variant="destructive"
-                            size="sm"
-                          >
-                            <Trash2 size={20} />
-                          </Button>
-                        </>
-                      ) : (
-                        <>
-                          <Button
-                            onClick={handleSave}
-                            disabled={saving}
-                            size="sm"
-                          >
-                            <Save size={20} style={{ marginRight: 'var(--spacing-2)' }} />
-                            {saving ? 'Saving...' : 'Save'}
-                          </Button>
-                          <Button
-                            onClick={() => {
-                              if (selectedPrompt) {
-                                loadPrompt(selectedPrompt.id);
-                              } else {
-                                setIsCreating(false);
-                                setIsEditing(false);
-                              }
-                            }}
-                            variant="secondary"
-                            size="sm"
-                          >
-                            <X size={20} style={{ marginRight: 'var(--spacing-2)' }} />
-                            Cancel
-                          </Button>
-                        </>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Description */}
-                  <div className="mb-4">
-                    {isEditing ? (
-                      <input
-                        type="text"
-                        value={description}
-                        onChange={(e) => setDescription(e.target.value)}
-                        placeholder="Optional description..."
-                        className="field body-text"
-                      />
-                    ) : (
-                      selectedPrompt?.description && (
-                        <p className="body-text" style={{ color: 'var(--color-text-muted)' }}>
-                          {selectedPrompt.description}
-                        </p>
-                      )
-                    )}
-                  </div>
-
-                  {/* Content Editor */}
-                  <div className="mb-4">
-                    <label className="block label-sm font-medium mb-2" style={{ color: 'var(--color-text)' }}>
-                      Profile Content
-                    </label>
-                    <textarea
-                      value={content}
-                      onChange={(e) => setContent(e.target.value)}
-                      disabled={!isEditing}
-                      placeholder="Tone, emphasis, and anything specific to your district..."
-                      className="field field-textarea"
-                      style={{
-                        width: '100%',
-                        height: '384px',
-                        fontFamily: 'SF Mono, ui-monospace, monospace',
-                        fontSize: '15px',
-                        resize: 'none',
-                        opacity: isEditing ? 1 : 0.7
-                      }}
-                    />
-                    <p className="caption mt-2" style={{ color: 'var(--color-text-muted)' }}>
-                      Characters: {content.length} | Lines: {content.split('\n').length}
-                    </p>
-                  </div>
-
-                  {/* Metadata */}
-                  {selectedPrompt && !isEditing && (
-                    <div className="mt-6 pt-6" style={{ borderTop: `0.5px solid var(--color-line)` }}>
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <p className="caption" style={{ color: 'var(--color-text-muted)' }}>Status</p>
-                          <p className="body-text font-medium" style={{ color: 'var(--color-text)' }}>
-                            {selectedPrompt.isActive ? (
-                              <span style={{ color: 'var(--color-text)' }}>Active</span>
-                            ) : (
-                              <span style={{ color: 'var(--color-text-muted)' }}>Inactive</span>
-                            )}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="caption" style={{ color: 'var(--color-text-muted)' }}>Last Updated</p>
-                          <p className="body-text font-medium" style={{ color: 'var(--color-text)' }}>
-                            {new Date(selectedPrompt.updatedAt).toLocaleDateString()}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <div className="text-center" style={{ padding: 'var(--spacing-8) 0' }}>
-                  <p className="body-text mb-4" style={{ color: 'var(--color-text-muted)' }}>No prompt selected</p>
-                  <Button onClick={handleCreateNew}>
-                    <Plus size={20} style={{ marginRight: 'var(--spacing-2)' }} />
-                    Create Your First Prompt
-                  </Button>
-                </div>
-              )}
-            </div>
-          </div>
+        <div className="mt-6 flex flex-wrap gap-x-10 gap-y-2 text-[13px] text-text-muted">
+          <span>
+            <span className="eyebrow mr-2">Status</span>
+            <span data-testid="profile-status">
+              {profile ? 'Active' : 'Using the shipped default'}
+            </span>
+          </span>
+          {profile && (
+            <span>
+              <span className="eyebrow mr-2">Last updated</span>
+              <span className="font-mono tabular-nums">{profile.updatedAt.slice(0, 10)}</span>
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/admin/prompt/page.tsx
+++ b/src/app/admin/prompt/page.tsx
@@ -231,9 +231,12 @@ export default function PromptEditorPage() {
                       justifyContent: 'flex-start'
                     }}
                   >
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between">
-                        <span className="label-sm font-medium truncate">{prompt.name}</span>
+                    {/* min-w-0 at both levels: `.list-row` is a flex container, so
+                        without it these items keep their content width and `truncate`
+                        never gets a bound to ellipsise against. */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="label-sm font-medium truncate min-w-0">{prompt.name}</span>
                         {/* Neutral: an isActive flag is not a deadline state. */}
                         {prompt.isActive && (
                           <span

--- a/src/app/admin/prompt/page.tsx
+++ b/src/app/admin/prompt/page.tsx
@@ -30,8 +30,6 @@ interface Profile {
   updatedAt: string;
 }
 
-const PROFILE_NAME = 'Advisor profile';
-
 export default function PromptEditorPage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [content, setContent] = useState('');
@@ -73,25 +71,14 @@ export default function PromptEditorPage() {
     }
     setSaving(true);
     try {
-      let id = profile?.id;
-
-      // No row yet: the district has been running on the in-code default.
-      if (!id) {
-        const created = await fetch('/api/admin/prompts', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: PROFILE_NAME, content }),
-        });
-        if (!created.ok) throw new Error('create failed');
-        id = (await created.json()).prompt.id as string;
-      }
-
-      // Always through PUT, including straight after a create: POST leaves a
-      // prompt inactive by design, and activation is what this write is for.
-      const response = await fetch(`/api/admin/prompts/${id}`, {
+      // One endpoint, which decides for itself whether that means updating the
+      // row already there or creating the first one. Choosing here meant
+      // POSTing whenever no profile was *active* -- not the same condition as
+      // none existing -- and minting a row nobody could reach on every save.
+      const response = await fetch('/api/admin/prompts/active', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content, isActive: true }),
+        body: JSON.stringify({ content }),
       });
       if (!response.ok) throw new Error('save failed');
 

--- a/src/app/api/admin/prompts/[id]/route.ts
+++ b/src/app/api/admin/prompts/[id]/route.ts
@@ -79,11 +79,16 @@ export async function PUT(request: NextRequest, { params }: Params) {
       });
     }
 
+    // `previousContent` moves only when the text actually changes. Activating a
+    // prompt, or renaming it, must not consume the one undo an admin has.
+    const contentChanged = content !== undefined && content !== before?.content;
+
     const prompt = await prisma.systemPrompt.update({
       where: { id },
       data: {
         ...(name !== undefined && { name }),
         ...(content !== undefined && { content }),
+        ...(contentChanged && { previousContent: before?.content ?? null }),
         ...(description !== undefined && { description }),
         ...(isActive !== undefined && { isActive })
       }
@@ -97,7 +102,7 @@ export async function PUT(request: NextRequest, { params }: Params) {
       details: {
         name: prompt.name,
         activated: isActive === true && before?.isActive !== true,
-        contentChanged: content !== undefined && content !== before?.content,
+        contentChanged,
         previousContent: before?.content,
       },
     });

--- a/src/app/api/admin/prompts/[id]/route.ts
+++ b/src/app/api/admin/prompts/[id]/route.ts
@@ -71,27 +71,32 @@ export async function PUT(request: NextRequest, { params }: Params) {
       select: { name: true, content: true, isActive: true },
     });
 
-    // If activating this prompt, deactivate all others
-    if (isActive) {
-      await prisma.systemPrompt.updateMany({
-        where: { isActive: true },
-        data: { isActive: false }
-      });
-    }
-
     // `previousContent` moves only when the text actually changes. Activating a
     // prompt, or renaming it, must not consume the one undo an admin has.
     const contentChanged = content !== undefined && content !== before?.content;
 
-    const prompt = await prisma.systemPrompt.update({
-      where: { id },
-      data: {
-        ...(name !== undefined && { name }),
-        ...(content !== undefined && { content }),
-        ...(contentChanged && { previousContent: before?.content ?? null }),
-        ...(description !== undefined && { description }),
-        ...(isActive !== undefined && { isActive })
+    // One transaction. Deactivating the others and activating this one were
+    // separate statements, so two concurrent activations could interleave and
+    // leave two rows active -- a state the chat path and the admin editor
+    // would then have to agree about by luck.
+    const prompt = await prisma.$transaction(async tx => {
+      if (isActive) {
+        await tx.systemPrompt.updateMany({
+          where: { isActive: true, id: { not: id } },
+          data: { isActive: false }
+        });
       }
+
+      return tx.systemPrompt.update({
+        where: { id },
+        data: {
+          ...(name !== undefined && { name }),
+          ...(content !== undefined && { content }),
+          ...(contentChanged && { previousContent: before?.content ?? null }),
+          ...(description !== undefined && { description }),
+          ...(isActive !== undefined && { isActive })
+        }
+      });
     });
 
     await recordAudit({

--- a/src/app/api/admin/prompts/active/route.ts
+++ b/src/app/api/admin/prompts/active/route.ts
@@ -1,15 +1,23 @@
-import { NextResponse } from 'next/server';
-import { prisma } from '@/lib/db';
+import { NextRequest, NextResponse } from 'next/server';
 import { requireRole } from '@/lib/session';
+import { findActiveProfile, saveActiveProfile } from '@/lib/system-prompt';
+import {
+  formatValidationErrors,
+  saveActiveProfileSchema,
+  validateRequest,
+} from '@/lib/validation';
+import { validationError } from '@/lib/errors';
+import { recordAudit } from '@/lib/audit';
 
 /**
- * The one profile the model is actually being sent, or null when none is
- * configured and the in-code default applies.
+ * The one advisor profile, read and written through the same resolution the
+ * chat path uses. A static segment beside `[id]`, so it takes precedence.
  *
- * A static segment beside `[id]`, so it takes precedence over it. It exists
- * because the editor otherwise needs two round trips to show one profile --
- * the list, which omits content by design, and then the row -- and the editor
- * cannot render until both have landed.
+ * It exists because the editor otherwise needed two round trips to show one
+ * profile -- the list, which omits content by design, and then the row -- and
+ * could not render until both had landed. The write side exists so "which row
+ * is the profile" is decided once, on the server, rather than by a client
+ * choosing between POST and PUT.
  */
 export async function GET() {
   try {
@@ -18,14 +26,39 @@ export async function GET() {
     const guard = await requireRole('admin');
     if (!guard.ok) return guard.response;
 
-    const prompt = await prisma.systemPrompt.findFirst({
-      where: { isActive: true },
-      orderBy: { updatedAt: 'desc' },
-    });
-
-    return NextResponse.json({ prompt: prompt ?? null });
+    return NextResponse.json({ prompt: (await findActiveProfile()) ?? null });
   } catch (error) {
     console.error('Error fetching the active prompt:', error);
     return NextResponse.json({ error: 'Failed to fetch the active prompt' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const guard = await requireRole('admin');
+    if (!guard.ok) return guard.response;
+
+    const parsed = validateRequest(saveActiveProfileSchema, await request.json());
+    if (!parsed.success) {
+      return validationError('Invalid advisor profile', formatValidationErrors(parsed.errors));
+    }
+
+    const saved = await saveActiveProfile(parsed.data.content, parsed.data.name);
+
+    await recordAudit({
+      userId: guard.user.id,
+      action: 'updated',
+      entity: 'systemPrompt',
+      entityId: saved.id,
+      details: {
+        contentChanged: saved.contentChanged,
+        previousContent: saved.contentChanged ? saved.previousContent : undefined,
+      },
+    });
+
+    return NextResponse.json({ prompt: saved });
+  } catch (error) {
+    console.error('Error saving the active prompt:', error);
+    return NextResponse.json({ error: 'Failed to save the active prompt' }, { status: 500 });
   }
 }

--- a/src/app/api/admin/prompts/active/route.ts
+++ b/src/app/api/admin/prompts/active/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { requireRole } from '@/lib/session';
+
+/**
+ * The one profile the model is actually being sent, or null when none is
+ * configured and the in-code default applies.
+ *
+ * A static segment beside `[id]`, so it takes precedence over it. It exists
+ * because the editor otherwise needs two round trips to show one profile --
+ * the list, which omits content by design, and then the row -- and the editor
+ * cannot render until both have landed.
+ */
+export async function GET() {
+  try {
+    // Admin-only. middleware.ts also gates /api/admin/*, but a matcher
+    // mistake must not silently expose policy or prompt mutation.
+    const guard = await requireRole('admin');
+    if (!guard.ok) return guard.response;
+
+    const prompt = await prisma.systemPrompt.findFirst({
+      where: { isActive: true },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    return NextResponse.json({ prompt: prompt ?? null });
+  } catch (error) {
+    console.error('Error fetching the active prompt:', error);
+    return NextResponse.json({ error: 'Failed to fetch the active prompt' }, { status: 500 });
+  }
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Send, Plus, Paperclip, Menu } from 'lucide-react';
 import Navbar from '@/components/Navbar';
@@ -162,7 +162,7 @@ export default function ChatPage() {
     }
   };
 
-  const loadConversation = async (chatId: string) => {
+  const loadConversation = useCallback(async (chatId: string) => {
     try {
       const response = await fetch(`/api/chat/${chatId}`);
       if (!response.ok) throw new Error('Failed to load conversation');
@@ -179,7 +179,24 @@ export default function ChatPage() {
       console.error('Error loading conversation:', error);
       toast.error('Failed to load conversation. Please try again.');
     }
-  };
+  }, []);
+
+  /*
+   * Open the incident named in `?incident=`, so an obligation row and the
+   * incident page have somewhere to send an administrator.
+   *
+   * Read from `window.location` in an effect rather than through
+   * `useSearchParams`, which would oblige this page to sit inside a Suspense
+   * boundary and stop being statically rendered. Nothing derives from it
+   * during render, so there is no hydration mismatch to guard.
+   *
+   * An id that is not the caller's own 404s in the route and is reported as a
+   * failure to load -- it is never confirmed to exist.
+   */
+  useEffect(() => {
+    const requested = new URLSearchParams(window.location.search).get('incident');
+    if (requested) loadConversation(requested);
+  }, [loadConversation]);
 
   const handleNewChat = () => {
     setMessages([]);

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -198,9 +198,30 @@ export default function ChatPage() {
     if (requested) loadConversation(requested);
   }, [loadConversation]);
 
+  /*
+   * The address follows the thread. `?incident=` is read on mount, so an
+   * address left naming a previous thread sends a reload somewhere the user
+   * has already navigated away from -- and a thread started here would have no
+   * address at all until it was reopened.
+   *
+   * Only ever set, never cleared: on mount `incidentId` is null while the
+   * deep-link effect above is still resolving, and clearing here would strip
+   * the parameter before it has been read. Starting a new chat clears it
+   * where that happens. `replaceState` rather than push, because opening a
+   * thread is not a step to go Back through.
+   */
+  useEffect(() => {
+    if (!incidentId) return;
+    if (new URLSearchParams(window.location.search).get('incident') === incidentId) return;
+    window.history.replaceState(null, '', `/chat?incident=${incidentId}`);
+  }, [incidentId]);
+
   const handleNewChat = () => {
     setMessages([]);
     setIncidentId(null);
+    // Cleared here rather than in the effect above, which must not strip the
+    // parameter while the deep link is still resolving it on mount.
+    window.history.replaceState(null, '', '/chat');
   };
 
   const handleSendMessage = async () => {

--- a/src/app/incidents/[id]/page.tsx
+++ b/src/app/incidents/[id]/page.tsx
@@ -354,6 +354,12 @@ export default function IncidentDetailPage() {
         </p>
 
         <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/chat?incident=${incident.id}`}
+            className="inline-flex min-h-[44px] items-center rounded-[12px] border border-line px-4 text-[14px] text-text-secondary transition-colors hover:border-line-strong hover:text-text"
+          >
+            Continue in chat
+          </Link>
           <button
             type="button"
             onClick={handleGenerateSummary}

--- a/src/components/design/ObligationRow.tsx
+++ b/src/components/design/ObligationRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { DeadlineClock } from './DeadlineClock';
 import { AuthorityChip } from './AuthorityChip';
 import { isPolicyBacked } from '@/lib/deadline';
@@ -87,8 +88,15 @@ export function ObligationRow({
             {obligation.description || obligation.actionType}
           </span>
 
+          {/* The title, not the row. `Mark done` is a button inside this row, and
+              an anchor wrapped around it would nest interactive elements. */}
           {obligation.incidentTitle && showIncident && (
-            <span className="text-[12px] text-text-muted">{obligation.incidentTitle}</span>
+            <Link
+              href={`/incidents/${obligation.incidentId}`}
+              className="w-fit text-[12px] text-text-muted underline underline-offset-2 hover:text-text"
+            >
+              {obligation.incidentTitle}
+            </Link>
           )}
 
           {!isPolicyBacked(obligation.deadlineSource) && !done && (

--- a/src/lib/ai/advisor-profile.ts
+++ b/src/lib/ai/advisor-profile.ts
@@ -1,0 +1,78 @@
+/**
+ * Tone, emphasis and district-specific context. Editable at /admin/prompt, and
+ * the fallback whenever no profile is active.
+ *
+ * Its own module, with no imports, because the admin editor needs the same
+ * text to offer "Restore original" and cannot pull in `claude-service.ts` --
+ * that reaches for Prisma and the Anthropic SDK. One copy, read by the server
+ * that sends it to the model and by the page that lets an admin edit it.
+ */
+export const DEFAULT_ADVISOR_PROFILE = `You are a trusted compliance advisor helping school administrators navigate incident reporting and investigation procedures. Think of yourself as a supportive colleague with legal expertise - you're here to help them handle this situation properly, ensure student safety, and make sure nothing important gets missed.
+
+YOUR APPROACH:
+Start with warmth and support. The administrator is likely stressed and needs clear, helpful guidance. Your primary goal is helping them understand what type of incident this is and guiding them through the proper next steps according to policy.
+
+WHAT YOU DO:
+1. **Help Gather the Full Picture** - Ask friendly clarifying questions to understand:
+   - Who is involved (students, staff, witnesses)
+   - What happened (specific behaviors/actions)
+   - When it occurred (date, time, duration)
+   - Where it took place (location, on/off campus)
+   - Whether parents have been notified
+   - Any immediate safety concerns
+
+   As you learn more, also gently check:
+   - Whether the superintendent has been contacted (important for serious incidents)
+   - Whether police have been notified if it might involve criminal conduct
+   - Whether they've consulted with legal counsel for complex situations
+
+2. **Help Identify the Incident Type** - Based on what they share, help them understand:
+   - What category this falls into (bullying, Title IX, harassment, violence, safety, etc.)
+   - Use "abuse_neglect" for any disclosure or suspicion of abuse or neglect of a child, including by someone outside the school
+   - How serious the situation is
+   - Which policies and regulations apply
+   - What this means for next steps
+
+3. **Guide Them Through Next Steps** - Share clear, actionable guidance on:
+   - What needs to happen right away (with specific timeframes)
+   - Required notifications (DCYF, police, parents, superintendent) and why they matter
+   - How to conduct the investigation properly
+   - What documentation is needed and where to record it
+   - Who else should be involved
+   - How to preserve evidence and secure witness statements
+   - Timeline requirements so nothing gets missed
+
+4. **Keep Them Compliant** - Help them understand requirements for:
+   - Mandatory reporting obligations (DCYF, police) with timeframes
+   - Title IX/Title VII requirements (federal law)
+   - FERPA privacy protections (student privacy)
+   - Safe Schools reporting (state requirements)
+   - PowerSchool logging (record keeping)
+   - SAU notification procedures
+   - When to involve superintendent or legal counsel
+
+YOUR COMMUNICATION STYLE:
+- Be warm, supportive, and encouraging - they came to you for help
+- Ask ONE clarifying question at a time when you need more information
+- Use bullet points and numbered lists to make action items crystal clear
+- Cite the exact provision you are relying on, as given with each excerpt, so they can look it up
+- Give exact timelines (e.g., "within 2 hours", "within 24 hours") so they know what's expected
+- Organize by priority (What to do right now → What to do today → Follow-up steps)
+- Use helpful headers like: "Here's what I'd recommend", "Let's make sure we cover", "Important timeline to know"
+- For serious incidents, gently remind them: "Have you had a chance to contact the superintendent about this?" or "Given what you've shared, have you notified police yet?"
+
+YOUR MINDSET:
+- You're helping them do this right and protect everyone involved
+- Documentation and proper procedure matter - help them understand why
+- Some deadlines are legally required - frame this as "here's what we need to make sure happens"
+- When you ask about notifications (superintendent, police, legal counsel), you're making sure nothing falls through the cracks
+- Due process protects everyone - students, staff, and the district
+- For Title IX, discrimination, or civil rights concerns, these require careful handling
+- When situations are complex or high-risk, legal counsel can provide specialized guidance
+
+WHEN YOU NEED MORE INFORMATION:
+- Ask specific questions in a supportive way: "To help me guide you better, can you tell me..."
+- If policies don't give clear guidance, be honest: "I don't see clear direction on this in our policies. This might be a good time to consult with legal counsel."
+- When in doubt about severity, suggest: "Given what you've described, it would be good to loop in the superintendent" or "This sounds like a situation where legal counsel's input would be valuable"
+
+Remember: You're here to help them navigate this successfully. Be their trusted advisor - knowledgeable, supportive, and focused on helping them take the right steps in the right order.`;

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { z } from 'zod';
-import { prisma } from '@/lib/db';
 import { logAIOperation, logError, logExternalAPI } from '@/lib/logger';
 import { INCIDENT_TYPES, PolicyCoverage, SEVERITIES } from '@/types';
 import { DEFAULT_ADVISOR_PROFILE } from './advisor-profile';
+import { findActiveProfile } from '@/lib/system-prompt';
 
 /**
  * The model's classification JSON, validated rather than trusted: whatever
@@ -303,10 +303,9 @@ class ClaudeService {
 
   private async getAdvisorProfile(): Promise<string | null> {
     try {
-      const activePrompt = await prisma.systemPrompt.findFirst({
-        where: { isActive: true },
-        select: { content: true }
-      });
+      // Through the same resolver the admin editor reads, so the profile an
+      // admin is looking at is the profile this call is sent.
+      const activePrompt = await findActiveProfile();
 
       return activePrompt?.content || null;
     } catch (error) {

--- a/src/lib/ai/claude-service.ts
+++ b/src/lib/ai/claude-service.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/db';
 import { logAIOperation, logError, logExternalAPI } from '@/lib/logger';
 import { INCIDENT_TYPES, PolicyCoverage, SEVERITIES } from '@/types';
+import { DEFAULT_ADVISOR_PROFILE } from './advisor-profile';
 
 /**
  * The model's classification JSON, validated rather than trusted: whatever
@@ -157,79 +158,7 @@ const CORE_DIRECTIVES = `NON-NEGOTIABLE RULES (these override anything below):
   "I could not find this in the loaded policy" is a useful answer; a
   confidently wrong obligation is not.`;
 
-/**
- * Tone, emphasis and district-specific context. Editable at /admin/prompt; this
- * is the fallback when no profile is active.
- */
-const DEFAULT_ADVISOR_PROFILE = `You are a trusted compliance advisor helping school administrators navigate incident reporting and investigation procedures. Think of yourself as a supportive colleague with legal expertise - you're here to help them handle this situation properly, ensure student safety, and make sure nothing important gets missed.
 
-YOUR APPROACH:
-Start with warmth and support. The administrator is likely stressed and needs clear, helpful guidance. Your primary goal is helping them understand what type of incident this is and guiding them through the proper next steps according to policy.
-
-WHAT YOU DO:
-1. **Help Gather the Full Picture** - Ask friendly clarifying questions to understand:
-   - Who is involved (students, staff, witnesses)
-   - What happened (specific behaviors/actions)
-   - When it occurred (date, time, duration)
-   - Where it took place (location, on/off campus)
-   - Whether parents have been notified
-   - Any immediate safety concerns
-
-   As you learn more, also gently check:
-   - Whether the superintendent has been contacted (important for serious incidents)
-   - Whether police have been notified if it might involve criminal conduct
-   - Whether they've consulted with legal counsel for complex situations
-
-2. **Help Identify the Incident Type** - Based on what they share, help them understand:
-   - What category this falls into (bullying, Title IX, harassment, violence, safety, etc.)
-   - Use "abuse_neglect" for any disclosure or suspicion of abuse or neglect of a child, including by someone outside the school
-   - How serious the situation is
-   - Which policies and regulations apply
-   - What this means for next steps
-
-3. **Guide Them Through Next Steps** - Share clear, actionable guidance on:
-   - What needs to happen right away (with specific timeframes)
-   - Required notifications (DCYF, police, parents, superintendent) and why they matter
-   - How to conduct the investigation properly
-   - What documentation is needed and where to record it
-   - Who else should be involved
-   - How to preserve evidence and secure witness statements
-   - Timeline requirements so nothing gets missed
-
-4. **Keep Them Compliant** - Help them understand requirements for:
-   - Mandatory reporting obligations (DCYF, police) with timeframes
-   - Title IX/Title VII requirements (federal law)
-   - FERPA privacy protections (student privacy)
-   - Safe Schools reporting (state requirements)
-   - PowerSchool logging (record keeping)
-   - SAU notification procedures
-   - When to involve superintendent or legal counsel
-
-YOUR COMMUNICATION STYLE:
-- Be warm, supportive, and encouraging - they came to you for help
-- Ask ONE clarifying question at a time when you need more information
-- Use bullet points and numbered lists to make action items crystal clear
-- Cite the exact provision you are relying on, as given with each excerpt, so they can look it up
-- Give exact timelines (e.g., "within 2 hours", "within 24 hours") so they know what's expected
-- Organize by priority (What to do right now → What to do today → Follow-up steps)
-- Use helpful headers like: "Here's what I'd recommend", "Let's make sure we cover", "Important timeline to know"
-- For serious incidents, gently remind them: "Have you had a chance to contact the superintendent about this?" or "Given what you've shared, have you notified police yet?"
-
-YOUR MINDSET:
-- You're helping them do this right and protect everyone involved
-- Documentation and proper procedure matter - help them understand why
-- Some deadlines are legally required - frame this as "here's what we need to make sure happens"
-- When you ask about notifications (superintendent, police, legal counsel), you're making sure nothing falls through the cracks
-- Due process protects everyone - students, staff, and the district
-- For Title IX, discrimination, or civil rights concerns, these require careful handling
-- When situations are complex or high-risk, legal counsel can provide specialized guidance
-
-WHEN YOU NEED MORE INFORMATION:
-- Ask specific questions in a supportive way: "To help me guide you better, can you tell me..."
-- If policies don't give clear guidance, be honest: "I don't see clear direction on this in our policies. This might be a good time to consult with legal counsel."
-- When in doubt about severity, suggest: "Given what you've described, it would be good to loop in the superintendent" or "This sounds like a situation where legal counsel's input would be valuable"
-
-Remember: You're here to help them navigate this successfully. Be their trusted advisor - knowledgeable, supportive, and focused on helping them take the right steps in the right order.`;
 
 /**
  * The last thing the model reads, in every branch.

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -1,0 +1,89 @@
+import { prisma } from '@/lib/db';
+
+/** There is only one profile, so its name is not a choice an admin makes. */
+export const DEFAULT_PROFILE_NAME = 'Advisor profile';
+
+/**
+ * Which advisor profile is in force, and how it is written.
+ *
+ * One function, because there were two: the chat path asked Prisma for the
+ * first row with `isActive`, and the admin editor asked with its own ordering.
+ * Nothing guaranteed they agreed, so an admin could be editing one profile
+ * while the model was being sent another, with nothing on screen saying so.
+ * On a tool that states statutory deadlines that is the worst shape of wrong:
+ * silent, and plausible.
+ *
+ * The database now refuses a second active row (see the partial unique index
+ * in `20260910_one_active_system_prompt`). The ordering below is what resolves
+ * a row written before that index existed, and is deterministic so that both
+ * callers resolve it the same way.
+ */
+export async function findActiveProfile() {
+  return prisma.systemPrompt.findFirst({
+    where: { isActive: true },
+    orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+  });
+}
+
+export interface SavedProfile {
+  id: string;
+  content: string;
+  previousContent: string | null;
+  isActive: boolean;
+  updatedAt: Date;
+  contentChanged: boolean;
+}
+
+/**
+ * Write the one advisor profile, creating it only if the table is empty.
+ *
+ * The editor used to POST whenever it held no active profile, which is not the
+ * same condition as "no profile exists" -- a row can be left inactive by a
+ * deactivation, and the single-profile UI shows no list -- so every save in
+ * that state minted another row that nobody could reach and that `findFirst`
+ * could later pick up.
+ *
+ * All of it in one transaction: deactivating the others and activating this
+ * one were separate statements, and two concurrent writes could interleave
+ * into two active rows.
+ */
+export async function saveActiveProfile(
+  content: string,
+  name: string = DEFAULT_PROFILE_NAME
+): Promise<SavedProfile> {
+  return prisma.$transaction(async tx => {
+    const existing =
+      (await tx.systemPrompt.findFirst({
+        where: { isActive: true },
+        orderBy: [{ updatedAt: 'desc' }, { id: 'asc' }],
+      })) ??
+      (await tx.systemPrompt.findFirst({ orderBy: { updatedAt: 'desc' } }));
+
+    if (!existing) {
+      const created = await tx.systemPrompt.create({
+        data: { name, content, isActive: true },
+      });
+      return { ...created, contentChanged: false };
+    }
+
+    await tx.systemPrompt.updateMany({
+      where: { isActive: true, id: { not: existing.id } },
+      data: { isActive: false },
+    });
+
+    // `previousContent` moves only when the text actually changes: activating
+    // a dormant row, or renaming it, must not consume the one undo an admin
+    // has.
+    const contentChanged = content !== existing.content;
+    const updated = await tx.systemPrompt.update({
+      where: { id: existing.id },
+      data: {
+        content,
+        isActive: true,
+        ...(contentChanged && { previousContent: existing.content }),
+      },
+    });
+
+    return { ...updated, contentChanged };
+  });
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -107,6 +107,18 @@ export const createPromptSchema = z.object({
 
 export type CreatePromptInput = z.infer<typeof createPromptSchema>;
 
+/**
+ * The single advisor profile write. `name` is optional because the editor does
+ * not offer one: there is only ever one profile, so naming it is not a choice
+ * the product asks an admin to make. `DEFAULT_PROFILE_NAME` fills it in.
+ */
+export const saveActiveProfileSchema = z
+  .object({
+    content: z.string().min(10, 'The profile needs at least 10 characters'),
+    name: z.string().min(1).max(100).optional(),
+  })
+  .strict();
+
 export const updatePromptSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   content: z.string().min(10).optional(),


### PR DESCRIPTION
Four commits, each doing one thing. All four gates green: `typecheck` 0, `lint` 0 errors (3 pre-existing warnings in `scripts/`), `build` 0, **227 unit + 90 e2e** (was 82).

Navigation the app was missing, then the Advisor tab rebuilt around the fact that only one profile can ever be active.

---

## `af8b904` — an obligation row can reach its incident

The queue is cross-incident, and a row named its incident in dead text. `incidentId` and `incidentTitle` were already on the object.

The link is on the **title, not the row**: `Mark done` is a `<button>` inside the row, and an anchor around it would nest interactive elements. Only the home queue is affected — `showIncident` is set there and nowhere else, so the incident page doesn't link back to itself.

Also fixes the saved-prompt buttons overflowing their card. `.list-row` is a flex container, so the `flex-1` child kept `min-width: auto` and the `truncate` already on the name and description had nothing to ellipsise against.

## `b561d1a` — a conversation is reachable by URL

Reopening a thread was only possible by clicking the sidebar, which is internal state. Nothing outside the chat page could link to a conversation — including the two places that most want to.

`/chat?incident=<id>` opens that thread, and the incident page carries **Continue in chat**.

The parameter is read from `window.location` in an effect rather than through `useSearchParams`, which would oblige an 862-line page into a Suspense boundary and stop it being statically rendered. The build still reports `○ /chat`. Nothing derives from the parameter during render, so there's no hydration mismatch. `loadConversation` became a `useCallback` so the effect can depend on it honestly rather than suppressing `exhaustive-deps`.

## `ddfdb9e` — one advisor profile

The tab listed saved profiles, but only one can ever be active, so the list offered a choice the product doesn't have — and it hid what it replaced. Creating a second profile silently displaced the in-code default, which appeared nowhere in that UI: an admin could not see, before or after, what wording they had stopped sending to the model.

One profile now, edited in place, with two ways back:

- **Restore original** loads `DEFAULT_ADVISOR_PROFILE`, read from the same constant the server sends. It moves to `src/lib/ai/advisor-profile.ts`, a module with no imports, because the editor cannot pull in `claude-service.ts` — that reaches for Prisma and the Anthropic SDK. One copy, read by the server that uses it and the page that edits it.
- **Undo last save** loads `SystemPrompt.previousContent`, captured on the PUT that changed the text — and only when the text actually changed, so activating or renaming cannot consume the one undo an admin has.

Neither writes on its own; both load into the editor so the admin sees the text before Save.

`GET /api/admin/prompts/active` is new, a static segment beside `[id]`. The editor otherwise needed two round trips to show one profile — the list, which omits content by design, then the row — and could not render until both landed.

### A schema fix that came with the migration

`@@index([policyId])` on `ComplianceAction` has existed since the obligation-provenance migration but was never declared in `schema.prisma`, so `migrate dev` proposed **dropping** it. `Policy` deletes cascade through that column with `onDelete: SetNull`, which would have gone to a sequential scan. The schema now declares it and the generated migration is the column alone.

---

## Testing

Six new e2e, each verified falsifiable:

| Test | Fails when |
|---|---|
| Obligation rows link to their incident | the `<Link>` is reverted to a `<span>` |
| `/chat?incident=` opens the thread | the effect is stubbed out |
| A foreign incident id reveals nothing | scoping regresses |
| Advisor shows the shipped default | — |
| Save, then undo the save after it | — |
| Restore original over an edit | — |
| A reporter is refused GET on all three admin prompt routes | the guard is missing from `/active` |

Two test-quality notes, both real bugs in my first attempt:

- The obligation-link assertion originally checked `rows[0]` against `open[0]` and passed on luck — the queue groups rows by deadline state and does not preserve API order. It asserts the hrefs as a **set** now.
- The profile test clicked Save and reloaded immediately, which aborts the PUT in flight (`ECONNRESET` in the server log) and leaves the row with its old text. Each save now waits for Save to go disabled, which is the app's own report that nothing unsaved remains. The profile tests also clear the row before each, because one asserts that no undo is offered before the first save — only true from a clean start, including on a retry.

Verified running against a local Postgres: `/admin/prompt` 200, `GET /api/admin/prompts/active` returns the profile, unauthenticated 401.

## `694f275` — review fixes

A Bastion review found four things. All four are fixed.

**1. The chat path and the editor disagreed about which profile is active.** `claude-service` asked `findFirst({ where: { isActive: true } })` with no ordering; the new `/active` endpoint ordered by `updatedAt`. With two active rows an admin edits one profile while the model is sent another, silently. Both now read `findActiveProfile` in `src/lib/system-prompt.ts`.

**2. Two rows could be active.** Nothing forbade it, and `PUT /[id]` deactivated the others and activated this one in separate statements, so concurrent writes could interleave. Activation is one transaction now, and a **partial unique index** makes a second active row impossible — raw SQL, since Prisma cannot express it, standing down extras first so the index builds on existing data. Verified: a direct `INSERT` of a second active row is rejected.

**3. Save minted a row every time when none was active.** The editor POSTed whenever it held no *active* profile, which is not the same condition as none existing — and with no list in the new UI those rows were unreachable, and any could later be resolved as the profile. `PUT /api/admin/prompts/active` decides on the server: reuse the row that is there, create only into an empty table.

**4. The chat address went stale.** `?incident=` is read on mount, so clicking a different thread left the address naming the old one and a reload went backwards; a thread started in the tab had no address at all. The address follows `incidentId` now, and is cleared on New chat — where it cannot race the deep link still resolving on mount.

Three more e2e for these: two saves leave exactly one row, a reporter is refused the new write verb, and the address both follows a new thread and is dropped when one starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
